### PR TITLE
Make the package Python3 compatible

### DIFF
--- a/pyramid_session_redis/__init__.py
+++ b/pyramid_session_redis/__init__.py
@@ -197,13 +197,13 @@ def RedisSessionFactory(
     If ``True`` will handle deserializtion errors by creating a new session.
 
     ``func_check_response_allow_cookies``
-    A callable function that accepts a response, returning ``True`` if the 
-    cookie can be sent and ``False`` if it should not.  This defaults to 
-    ``None``.  An example callable is available in 
-    ``check_response_allow_cookies``, which checks for `expires` and 
+    A callable function that accepts a response, returning ``True`` if the
+    cookie can be sent and ``False`` if it should not.  This defaults to
+    ``None``.  An example callable is available in
+    ``check_response_allow_cookies``, which checks for `expires` and
     `cache-control` cookies.
 
-    
+
     The following arguments are also passed straight to the ``StrictRedis``
     constructor and allow you to further configure the Redis client::
 
@@ -262,7 +262,7 @@ def RedisSessionFactory(
                 detect_changes=detect_changes,
                 deserialized_fails_new=deserialized_fails_new,
                 )
-        except InvalidSession, e:
+        except InvalidSession:
             session_id = new_session()
             session_cookie_was_valid = False
             session = RedisSession(

--- a/pyramid_session_redis/compat.py
+++ b/pyramid_session_redis/compat.py
@@ -3,6 +3,9 @@
 """
 Compatability module for various pythons and environments.
 """
+import sys
+
+PY3 = sys.version_info[0] == 3
 
 
 try:
@@ -10,3 +13,23 @@ try:
 except ImportError:  # pragma: no cover
     # python 3 pickle module
     import pickle as cPickle
+
+
+try:
+    # python3.6 secretc module
+    from secrets import token_urlsafe, token_hex
+except ImportError: # pragma: no cover
+    import os
+    import base64
+    import binascii
+
+    def token_bytes(nbytes=32):
+        return os.urandom(nbytes)
+
+    def token_urlsafe(nbytes=32):
+        token = base64.urlsafe_b64encode(token_bytes(nbytes)).rstrip(b'=')
+        return token.decode('ascii') if PY3 else token
+
+    def token_hex(nbytes=32):
+        token = binascii.hexlify(token_bytes(nbytes))
+        return token.decode('ascii') if PY3 else token

--- a/pyramid_session_redis/session.py
+++ b/pyramid_session_redis/session.py
@@ -1,15 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import binascii
-import os
 import hashlib
 
-from pyramid.compat import text_
 from pyramid.decorator import reify
 from pyramid.interfaces import ISession
 from zope.interface import implementer
 
-from .compat import cPickle
+from .compat import cPickle, token_hex
 from .exceptions import InvalidSession
 from .util import (
     persist,
@@ -348,7 +345,7 @@ class RedisSession(object):
 
     # session methods persist or refresh using above dict methods
     def new_csrf_token(self):
-        token = text_(binascii.hexlify(os.urandom(20)))
+        token = token_hex(32)
         self['_csrft_'] = token
         return token
 

--- a/pyramid_session_redis/session.py
+++ b/pyramid_session_redis/session.py
@@ -117,7 +117,7 @@ class RedisSession(object):
 
     ``detect_changes``
     If ``True``, supports change detection Default: ``True``
-    
+
     ``deserialized_fails_new``
     If ``True`` will handle deserializtion errors by creating a new session.
     """
@@ -218,10 +218,10 @@ class RedisSession(object):
             raise InvalidSession("`session_id` (%s) not in Redis" % session_id)
         try:
             deserialized = self.deserialize(persisted)
-        except Exception, e:
+        except Exception:
             if self._deserialized_fails_new:
                 raise InvalidSession("`session_id` (%s) did not deserialize correctly" % session_id)
-            raise e
+            raise
         if persisted_hash is True:
             return (deserialized, hashed_value(persisted))
         elif persisted_hash is False:

--- a/pyramid_session_redis/util.py
+++ b/pyramid_session_redis/util.py
@@ -1,17 +1,12 @@
 # -*- coding: utf-8 -*-
 
 from functools import partial
-import base64
-import os
-import sys
 import time
 
 from pyramid.exceptions import ConfigurationError
 from pyramid.settings import asbool
 from redis.exceptions import WatchError
-
-
-PY3 = sys.version_info[0] == 3
+from .compat import PY3, token_urlsafe
 
 
 def to_binary(value, enc="UTF-8"):  # pragma: no cover
@@ -28,7 +23,7 @@ def to_unicode(value):  # pragma: no cover
 
 def _generate_session_id():
     """
-    Produces a base64 encoded, urlsafe random string with 20-byte
+    Produces a base64 encoded, urlsafe random string with 32-byte
     cryptographically strong randomness as the session id. See
 
         http://security.stackexchange.com/questions/24850/
@@ -36,18 +31,12 @@ def _generate_session_id():
 
     for the algorithm of choosing a session id.
 
-    The code is adapted from the standard library secrets of python3.6, see
-
-        https://docs.python.org/3.6/library/secrets.html
-
     The implementation of `os.urandom` varies by system, but you can always
     supply your own function in your ini file with:
 
         redis.sessions.id_generator = my_random_id_generator
     """
-    rand = os.urandom(20)
-    session_id = base64.urlsafe_b64encode(rand).rstrip(b'=')
-    return session_id.decode('ascii') if PY3 else session_id
+    return token_urlsafe(32)
 
 
 def prefixed_id(prefix='session:'):


### PR DESCRIPTION
Hi jvanasco,

It's great to know that the pyramid_redis_sessions library gets further maintained. I have been bothered since a long time with the multiple EXPIRE requests with each session attribute access and am glad finally it is got fixed.

However the latest master is not python3 compatible:

```
  File "/home/hong/python3/lib/python3.5/site-packages/pyramid/path.py", line 320, in maybe_resolve
    return self._resolve(dotted, package)
  File "/home/hong/python3/lib/python3.5/site-packages/pyramid/path.py", line 327, in _resolve
    return self._zope_dottedname_style(dotted, package)
  File "/home/hong/python3/lib/python3.5/site-packages/pyramid/path.py", line 376, in _zope_dottedname_style
    found = __import__(used)
  File "/home/hong/python3/lib/python3.5/site-packages/pyramid_session_redis/__init__.py", line 265
    except InvalidSession, e:
                         ^
SyntaxError: invalid syntax
```
Because in python3, the `except` clause no longer receives an exception object with python2 syntax: 

`  except Exception, e`

but rather:

` except Exception as e`

In the original code, exception objects are specified but never used. So we can just eliminate them all.

A second point is that although the original default session generator creates strong random session id strings, they are 64 characters long with 20-byte randomness. The additional hashes are not necessary according to the article:

http://security.stackexchange.com/questions/24850/choosing-a-session-id-algorithm-for-a-client-server-relationship

Specifically quote:

> There is little point in throwing an extra hash function in the thing. Properly applied randomness will already give you all the uniqueness you need. Added complexity can only result in added weaknesses.

The additional two passes of sha256 bloat the length of session id string, slow down the session id creation, at no additional benefit.

My suggestion is to use the code from secrets.token_urlsafe(20) from python3.6 standard library as the default session_id generator. See:

https://docs.python.org/3.6/library/secrets.html
https://www.python.org/dev/peps/pep-0506/

With the update, the average session id length is reduced to 27 characters while remaining browser-friendly and cryptographically equally strong.
