### PR TITLE
Fix/refactor assume_redis_lru function

### DIFF
--- a/pyramid_session_redis/__init__.py
+++ b/pyramid_session_redis/__init__.py
@@ -104,7 +104,7 @@ def RedisSessionFactory(
     serialize=cPickle.dumps,
     deserialize=cPickle.loads,
     id_generator=_generate_session_id,
-    assume_redis_lru=None,
+    assume_redis_lru=False,
     detect_changes=True,
     deserialized_fails_new=None,
     func_check_response_allow_cookies=None,
@@ -188,8 +188,8 @@ def RedisSessionFactory(
     ``assume_redis_lru``
     Boolean value. If set to ``True``, will assume that redis is configured as
     a least-recently-used cache [http://redis.io/topics/lru-cache] and will NOT
-    sent EXPIRY data for sessions.
-    Default: ``None``
+    send EXPIRY data for sessions (so the value of `timeout` will be ignored).
+    Default: ``False``
 
     ``detect_changes``
     Boolean value. If set to ``True``, will calculate nested changes after
@@ -216,6 +216,10 @@ def RedisSessionFactory(
       errors
       unix_socket_path
     """
+    # ignore the value of `timeout` if configured for LRU mode
+    if assume_redis_lru:
+        timeout = None
+
     def factory(request, new_session_id=get_unique_session_id):
         redis_options = dict(
             host=host,
@@ -261,7 +265,6 @@ def RedisSessionFactory(
                 new_session=new_session,
                 serialize=serialize,
                 deserialize=deserialize,
-                assume_redis_lru=assume_redis_lru,
                 detect_changes=detect_changes,
                 deserialized_fails_new=deserialized_fails_new,
                 )
@@ -275,7 +278,6 @@ def RedisSessionFactory(
                 new_session=new_session,
                 serialize=serialize,
                 deserialize=deserialize,
-                assume_redis_lru=assume_redis_lru,
                 detect_changes=detect_changes,
                 )
 

--- a/pyramid_session_redis/tests/__init__.py
+++ b/pyramid_session_redis/tests/__init__.py
@@ -17,7 +17,6 @@ class DummySession(object):
         self.serialize = serialize
         self.managed_dict = {}
         self.created = float()
-        self._assume_redis_lru = None
         self._session_state = DummySessionState()
 
     def to_redis(self):


### PR DESCRIPTION
The assume_redis_lru option added in 705e9da5 wasn't functioning as
expected. This commit makes a few changes (with some minor refactoring)
to get what I think was the intended behavior:

* Remove _assume_redis_lru attr from RedisSession and infer it from
  .timeout being set to None (done automatically in RedisSessionFactory
  if assume_redis_lru is True).
* Don't include the timeout key/value in the stored session when in LRU
  mode - it isn't needed, and this reduces the size of each item
  slightly.
* Use redis SET command instead of SETEX when no timeout is set.
* Turn RedisSession.do_refresh() into a no-op when no timeout is set.
* Throw an error if the configuration both enables assume_redis_lru and
  tries to set a timeout value, since these cannot work together.