### PR TITLE
Fix issue 11/16

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,3 +6,26 @@ TODO
 
 The testsuite needs to test that timeout trigger is being correctly triggered 
 via a short test with `sleep`.
+
+The edgecase that we are trying to recreate:
+
+https://github.com/jvanasco/pyramid_session_redis/issues/11
+
+```
+redis.sessions.secret = <removed>
+redis.sessions.unix_socket_path = /run/redis/socket
+redis.sessions.prefix = session:
+redis.sessions.cookie_secure = true
+redis.sessions.cookie_max_age = 31536000
+redis.sessions.timeout = 3600
+```
+
+* A user comes to the site without a session, so they're not logged in and a new session is created for them in redis, with timeout 3600 seconds.
+* They log in, and I use adjust_timeout_for_session() to set their timeout to either 1 day or 1 year, depending if they checked the "keep me logged in" box or not.
+* If I examine the actual session data stored in redis at this point, the TTL on the redis key has been updated to the correct value (86400 or 31536000), but the x value stored inside the python dict is still 3600, and the t value is still the original 1-hour-later timestamp.
+
+the internal payload should be updated along with the redis TTL.
+
+`test_timeout_trigger` has been started, but should be refactored. it doesn't seem to work as expected regarding the number of redis hits.
+
+

--- a/pyramid_session_redis/session.py
+++ b/pyramid_session_redis/session.py
@@ -178,7 +178,7 @@ class RedisSession(object):
     ):
         if timeout_trigger and not python_expires:  # fix this
             python_expires = True
-        self._optimize_refresh = True if (timeout and not timeout_trigger and not python_expires) else False
+        self._optimize_refresh = True if (timeout and not timeout_trigger and not python_expires and set_redis_ttl) else False
         self.redis = redis
         self.serialize = serialize
         self.deserialize = deserialize

--- a/pyramid_session_redis/session.py
+++ b/pyramid_session_redis/session.py
@@ -393,7 +393,7 @@ class RedisSession(object):
         self.ensure_id()
         if serialized_session is None:
             serialized_session = self.to_redis()
-        serverside_timeout = True if self.timeout is not None and self._set_redis_ttl else False
+        serverside_timeout = True if ((self.timeout is not None) and (self._set_redis_ttl)) else False
         if serverside_timeout:
             self.redis.setex(self.session_id, self.timeout, serialized_session)
         else:

--- a/pyramid_session_redis/tests/__init__.py
+++ b/pyramid_session_redis/tests/__init__.py
@@ -106,6 +106,7 @@ class DummyPipeline(object):
 
     def get(self, key):
         self._history.append(('get', key, ))
+        self._redis_con._history.append(('pipeline.get', key, ))
         return self.store.get(key)
 
     def expire(self, key, timeout):

--- a/pyramid_session_redis/tests/__init__.py
+++ b/pyramid_session_redis/tests/__init__.py
@@ -50,6 +50,7 @@ class DummyRedis(object):
         return redis
 
     def get(self, key):
+        self._history.append(('get', key, ))
         return self.store.get(key)
 
     def set(self, key, value, debug=None):
@@ -104,6 +105,7 @@ class DummyPipeline(object):
         self._redis_con._history.append(('pipeline.set', key, value, debug))
 
     def get(self, key):
+        self._history.append(('get', key, ))
         return self.store.get(key)
 
     def expire(self, key, timeout):

--- a/pyramid_session_redis/tests/test_factory.py
+++ b/pyramid_session_redis/tests/test_factory.py
@@ -1119,9 +1119,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data)
         self.assertEqual(stored_session_data['x'], stored_session_data['c'] + stored_session_data['t'])
 
-        # there should be 1 items in the history:
+        # there should be 3 items in the history:
         # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'setex')
         self.assertEqual(request.registry._redis_sessions._history[0][2], session_args['timeout'])
 
@@ -1137,7 +1139,9 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
 
         # there should be 1 items in the history:
         # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'setex')
         self.assertEqual(request.registry._redis_sessions._history[0][2], session_args['timeout'])
 
@@ -1150,9 +1154,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data)
         self.assertEqual(stored_session_data['x'], stored_session_data['c'] + stored_session_data['t'])
 
-        # there should be 1 items in the history:
+        # there should be 3 items in the history:
         # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'setex')
         self.assertEqual(request.registry._redis_sessions._history[0][2], session_args['timeout'])
 
@@ -1167,9 +1173,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be 1 items in the history:
+        # there should be 3 items in the history:
         # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'setex')
         self.assertEqual(request.registry._redis_sessions._history[0][2], session_args['timeout'])
 
@@ -1186,9 +1194,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be 1 items in the history:
+        # there should be 3 items in the history:
         # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)        
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'setex')
         self.assertEqual(request.registry._redis_sessions._history[0][2], session_args['timeout'])
 
@@ -1201,9 +1211,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be 1 items in the history:
+        # there should be 3 items in the history:
         # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'setex')
         self.assertEqual(request.registry._redis_sessions._history[0][2], session_args['timeout'])
 
@@ -1215,9 +1227,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be 1 items in the history:
+        # there should be 3 items in the history:
         # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'setex')
         self.assertEqual(request.registry._redis_sessions._history[0][2], session_args['timeout'])
 
@@ -1229,9 +1243,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be 1 items in the history:
+        # there should be 3 items in the history:
         # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'setex')
         self.assertEqual(request.registry._redis_sessions._history[0][2], session_args['timeout'])
 
@@ -1385,9 +1401,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data)
         self.assertEqual(stored_session_data['x'], stored_session_data['c'] + stored_session_data['t'])
 
-        # there should be 1 items in the history:
-        # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # there should be 3 items in the history:
+        # 0 = a SET for the initial creation
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'set')
 
     def test_scenario_existing__timeout_trigger_pythonNoExpires_noRedisTtl_noChange(self):
@@ -1399,9 +1417,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertIn('x', stored_session_data)
 
-        # there should be 1 items in the history:
-        # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # there should be 3 items in the history:
+        # 0 = a SET for the initial creation
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'set')
 
     def test_scenario_existing__timeout_noTrigger_pythonExpires_noRedisTtl_noChange(self):
@@ -1413,9 +1433,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data)
         self.assertEqual(stored_session_data['x'], stored_session_data['c'] + stored_session_data['t'])
 
-        # there should be 1 items in the history:
+        # there should be 3 items in the history:
         # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'set')
 
     def test_scenario_existing__timeout_noTrigger_noPythonExpires_noRedisTtl_noChange(self):
@@ -1430,8 +1452,8 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertNotIn('x', stored_session_data)
 
         # there should be 1 items in the history:
-        # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # 0 = a SET for the initial creation
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'set')
 
     # --------------------------------------------------------------------------
@@ -1447,9 +1469,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be 1 items in the history:
-        # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # there should be 3 items in the history:
+        # 0 = a SET for the initial creation
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'set')
 
     def test_scenario_existing__noTimeout_trigger_pythonNoExpires_noRedisTtl(self):
@@ -1462,8 +1486,10 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertNotIn('x', stored_session_data)
 
         # there should be 1 items in the history:
-        # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # 0 = a SET for the initial creation
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'set')
 
     def test_scenario_existing__noTimeout_noTrigger_pythonExpires_noRedisTtl(self):
@@ -1475,8 +1501,10 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertNotIn('x', stored_session_data)
 
         # there should be 1 items in the history:
-        # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # 0 = a SET for the initial creation
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'set')
 
     def test_scenario_existing__noTimeout_noTrigger_noPythonExpires_noRedisTtl(self):
@@ -1489,7 +1517,9 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
 
         # there should be 1 items in the history:
         # 0 = a SETEX for the initial creation
-        self.assertEqual(len(request.registry._redis_sessions._history), 1)
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'set')
 
     # --------------------------------------------------------------------------
@@ -1508,9 +1538,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         request1 = self._prep_existing_session(session_args)
         stored_session_data_1_pre = self._deserialize_session_stored(request1.session)
 
-        # there should be 1 items in the history:
+        # there should be 3 items in the history:
         # 0 = a SET for the initial creation
-        self.assertEqual(len(request1.registry._redis_sessions._history), 1)
+        # 1 = GET
+        # 2 = GET
+        self.assertEqual(len(request1.registry._redis_sessions._history), 3)
         self.assertEqual(request1.registry._redis_sessions._history[0][0], 'set')
 
         # let's adjust the timeout and make a request that won't change anything
@@ -1520,9 +1552,12 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data_1_post)
         self.assertEqual(stored_session_data_1_post['x'], stored_session_data_1_pre['x'] + timeout_diff_1)
 
-        # there should still be 1 items in the history:
+        # there should still be 4 items in the history:
         # 0 = a SET for the initial creation
-        self.assertEqual(len(request1.registry._redis_sessions._history), 1)
+        # 1 = GET
+        # 2 = GET
+        # 3 = GET
+        self.assertEqual(len(request1.registry._redis_sessions._history), 4)
         self.assertEqual(request1.registry._redis_sessions._history[0][0], 'set')
 
         #
@@ -1534,11 +1569,14 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data_unchanged)
         self.assertEqual(stored_session_data_unchanged['x'], stored_session_data_1_post['x'])
 
-        # there should still be 1 items in the history:
+        # there should still be 5 items in the history:
         # 0 = a SET for the initial insert -- but it's not triggered by RedisSession
-        # 0 = a SET for the update adjust -- which is triggered by RedisSession
+        # 1 = GET
+        # 2 = GET
+        # 3 = GET
+        # 4 = GET
         self.assertIs(request_unchanged.registry._redis_sessions, request1.registry._redis_sessions)
-        self.assertEqual(len(request_unchanged.registry._redis_sessions._history), 1)
+        self.assertEqual(len(request_unchanged.registry._redis_sessions._history), 5)
         self.assertEqual(request_unchanged.registry._redis_sessions._history[0][0], 'set')
 
         #
@@ -1561,11 +1599,17 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
 
         # there should be 2 items in the history:
         # 0 = a SET for the initial insert -- but it's not triggered by RedisSession
-        # 0 = a SET for the update adjust -- which is triggered by RedisSession
+        # 1 = GET
+        # 2 = GET
+        # 3 = GET
+        # 4 = GET
+        # 5 = GET
+        # 6 = GET
+        # 7 = a SET for the update adjust -- which is triggered by RedisSession
         self.assertIs(request_updated.registry._redis_sessions, request_unchanged.registry._redis_sessions)
-        self.assertEqual(len(request_updated.registry._redis_sessions._history), 2)
+        self.assertEqual(len(request_updated.registry._redis_sessions._history), 8)
         self.assertEqual(request_updated.registry._redis_sessions._history[0][0], 'set')
-        self.assertEqual(request_updated.registry._redis_sessions._history[1][0], 'set')
+        self.assertEqual(request_updated.registry._redis_sessions._history[7][0], 'set')
         return
 
     def test_scenario_flow__timeout_trigger_pythonExpires_setRedisTtl(self):
@@ -1580,9 +1624,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         request1 = self._prep_existing_session(session_args)
         stored_session_data_1_pre = self._deserialize_session_stored(request1.session)
 
-        # there should be 1 items in the history:
-        # 0 = a SET for the initial creation
-        self.assertEqual(len(request1.registry._redis_sessions._history), 1)
+        # there should be 3 items in the history:
+        # 0 = a SETEX for the initial creation
+        # 1 = a GET
+        # 2 = a GET
+        self.assertEqual(len(request1.registry._redis_sessions._history), 3)
         self.assertEqual(request1.registry._redis_sessions._history[0][0], 'setex')
 
         # let's adjust the timeout and make a request that won't change anything
@@ -1592,9 +1638,12 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data_1_post)
         self.assertEqual(stored_session_data_1_post['x'], stored_session_data_1_pre['x'] + timeout_diff_1)
 
-        # there should still be 1 items in the history:
-        # 0 = a SET for the initial creation
-        self.assertEqual(len(request1.registry._redis_sessions._history), 1)
+        # there should be 4 items in the history:
+        # 0 = a SETEX for the initial creation
+        # 1 = a GET
+        # 2 = a GET
+        # 4 = a GET
+        self.assertEqual(len(request1.registry._redis_sessions._history), 4)
         self.assertEqual(request1.registry._redis_sessions._history[0][0], 'setex')
 
         #
@@ -1606,11 +1655,14 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data_unchanged)
         self.assertEqual(stored_session_data_unchanged['x'], stored_session_data_1_post['x'])
 
-        # there should still be 1 items in the history:
-        # 0 = a SET for the initial insert -- but it's not triggered by RedisSession
-        # 0 = a SET for the update adjust -- which is triggered by RedisSession
+        # there should be 4 items in the history:
+        # 0 = a SETEX for the initial creation
+        # 1 = a GET
+        # 2 = a GET
+        # 4 = a GET
+        # 5 = a GET
         self.assertIs(request_unchanged.registry._redis_sessions, request1.registry._redis_sessions)
-        self.assertEqual(len(request_unchanged.registry._redis_sessions._history), 1)
+        self.assertEqual(len(request_unchanged.registry._redis_sessions._history), 5)
         self.assertEqual(request_unchanged.registry._redis_sessions._history[0][0], 'setex')
 
         #
@@ -1632,12 +1684,17 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertEqual(stored_session_data_updated['x'], time_now + session_args['timeout'])
 
         # there should be 2 items in the history:
-        # 0 = a SET for the initial insert -- but it's not triggered by RedisSession
-        # 0 = a SET for the update adjust -- which is triggered by RedisSession
+        # 0 = a SETEX for the initial creation - but it's not triggered by RedisSession
+        # 1 = a GET
+        # 2 = a GET
+        # 4 = a GET
+        # 5 = a GET
+        # 6 = a GET
+        # 7 = a SETEX for the update adjust -- which is triggered by RedisSession
         self.assertIs(request_updated.registry._redis_sessions, request_unchanged.registry._redis_sessions)
-        self.assertEqual(len(request_updated.registry._redis_sessions._history), 2)
+        self.assertEqual(len(request_updated.registry._redis_sessions._history), 8)
         self.assertEqual(request_updated.registry._redis_sessions._history[0][0], 'setex')
-        self.assertEqual(request_updated.registry._redis_sessions._history[1][0], 'setex')
+        self.assertEqual(request_updated.registry._redis_sessions._history[7][0], 'setex')
         return
 
     def test_scenario_flow__noCookie_a(self):

--- a/pyramid_session_redis/tests/test_factory.py
+++ b/pyramid_session_redis/tests/test_factory.py
@@ -974,14 +974,16 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data)
         self.assertEqual(stored_session_data['x'], stored_session_data['c'] + stored_session_data['t'])
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SETEX for the initial creation
-        # 1 = a SETEX for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.setex')
-        self.assertEqual(request.registry._redis_sessions._history[0][2], session_args['timeout'])
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'setex')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SETEX for the initial creation
+        # 2 = a SETEX for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.setex')
         self.assertEqual(request.registry._redis_sessions._history[1][2], session_args['timeout'])
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'setex')
+        self.assertEqual(request.registry._redis_sessions._history[2][2], session_args['timeout'])
 
     def test_scenario_new__timeout_trigger_pythonNoExpires_setRedisTtl(self):
         # note: timeout-trigger will force python_expires
@@ -993,14 +995,16 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data)
         self.assertEqual(stored_session_data['x'], stored_session_data['c'] + stored_session_data['t'])
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SETEX for the initial creation
-        # 1 = a SETEX for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.setex')
-        self.assertEqual(request.registry._redis_sessions._history[0][2], session_args['timeout'])
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'setex')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the id
+        # 1 = a pipeline.SETEX for the initial creation
+        # 2 = a SETEX for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.setex')
         self.assertEqual(request.registry._redis_sessions._history[1][2], session_args['timeout'])
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'setex')
+        self.assertEqual(request.registry._redis_sessions._history[2][2], session_args['timeout'])
 
     def test_scenario_new__timeout_noTrigger_pythonExpires_setRedisTtl(self):
         session_args = self._args_timeout_noTrigger_pythonExpires_setRedisTtl
@@ -1011,14 +1015,16 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data)
         self.assertEqual(stored_session_data['x'], stored_session_data['c'] + stored_session_data['t'])
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SETEX for the initial creation
-        # 1 = a SETEX for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.setex')
-        self.assertEqual(request.registry._redis_sessions._history[0][2], session_args['timeout'])
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'setex')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SETEX for the initial creation
+        # 2 = a SETEX for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.setex')
         self.assertEqual(request.registry._redis_sessions._history[1][2], session_args['timeout'])
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'setex')
+        self.assertEqual(request.registry._redis_sessions._history[2][2], session_args['timeout'])
 
     def test_scenario_new__timeout_noTrigger_noPythonExpires_setRedisTtl(self):
         """
@@ -1031,14 +1037,16 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SETEX for the initial creation
-        # 1 = a SETEX for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.setex')
-        self.assertEqual(request.registry._redis_sessions._history[0][2], session_args['timeout'])
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'setex')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SETEX for the initial creation
+        # 2 = a SETEX for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.setex')
         self.assertEqual(request.registry._redis_sessions._history[1][2], session_args['timeout'])
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'setex')
+        self.assertEqual(request.registry._redis_sessions._history[2][2], session_args['timeout'])
 
     # --------------------------------------------------------------------------
     # new session - no timeout
@@ -1054,11 +1062,13 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertNotIn('x', stored_session_data)
 
         # there should be two items in the history:
-        # 0 = a pipeline.SET for the initial creation
-        # 1 = a SET for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.set')
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'set')
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SET for the initial creation
+        # 2 = a SET for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.set')
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'set')
 
     def test_scenario_new__noTimeout_trigger_pythonNoExpires_setRedisTtl(self):
         """the ``timeout_trigger`` is irrelevant"""
@@ -1069,12 +1079,14 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SET for the initial creation
-        # 1 = a SET for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.set')
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'set')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SET for the initial creation
+        # 2 = a SET for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.set')
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'set')
 
     def test_scenario_new__noTimeout_noTrigger_pythonExpires_setRedisTtl(self):
         session_args = self._args_noTimeout_noTrigger_pythonExpires_setRedisTtl
@@ -1084,12 +1096,14 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SET for the initial creation
-        # 1 = a SET for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.set')
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'set')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SET for the initial creation
+        # 2 = a SET for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.set')
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'set')
 
     def test_scenario_new__noTimeout_noTrigger_noPythonExpires_setRedisTtl(self):
         session_args = self._args_noTimeout_noTrigger_noPythonExpires_setRedisTtl
@@ -1099,12 +1113,14 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SET for the initial creation
-        # 1 = a SET for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.set')
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'set')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SET for the initial creation
+        # 2 = a SET for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.set')
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'set')
 
     # --------------------------------------------------------------------------
     # existing session - timeout
@@ -1175,9 +1191,11 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
 
         # there should be 3 items in the history:
         # 0 = a SETEX for the initial creation
-        # 1 = GET
-        # 2 = GET
-        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        # 1 = pipeline.get
+        # 2 = pipeline.expire
+        # 3 = pipeline.get
+        # 4 = pipeline.expire
+        self.assertEqual(len(request.registry._redis_sessions._history), 5)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'setex')
         self.assertEqual(request.registry._redis_sessions._history[0][2], session_args['timeout'])
 
@@ -1264,12 +1282,14 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data)
         self.assertEqual(stored_session_data['x'], stored_session_data['c'] + stored_session_data['t'])
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SETEX for the initial creation
-        # 1 = a SETEX for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.set')
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'set')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SET for the initial creation
+        # 2 = a SET for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.set')
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'set')
 
     def test_scenario_new__timeout_trigger_pythonNoExpires_noRedisTtl(self):
         # note: timeout-trigger will force python_expires
@@ -1281,12 +1301,14 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data)
         self.assertEqual(stored_session_data['x'], stored_session_data['c'] + stored_session_data['t'])
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SETEX for the initial creation
-        # 1 = a SETEX for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.set')
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'set')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SET for the initial creation
+        # 2 = a SET for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.set')
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'set')
 
     def test_scenario_new__timeout_noTrigger_pythonExpires_noRedisTtl(self):
         session_args = self._args_timeout_noTrigger_pythonExpires_noRedisTtl
@@ -1297,12 +1319,14 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         self.assertIn('x', stored_session_data)
         self.assertEqual(stored_session_data['x'], stored_session_data['c'] + stored_session_data['t'])
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SETEX for the initial creation
-        # 1 = a SETEX for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.set')
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'set')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SET for the initial creation
+        # 2 = a SET for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.set')
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'set')
 
     def test_scenario_new__timeout_noTrigger_noPythonExpires_noRedisTtl(self):
         """
@@ -1315,12 +1339,14 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SETEX for the initial creation
-        # 1 = a SETEX for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.set')
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'set')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SET for the initial creation
+        # 2 = a SET for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.set')
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'set')
 
     # --------------------------------------------------------------------------
     # new session - no timeout
@@ -1335,12 +1361,14 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SET for the initial creation
-        # 1 = a SET for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.set')
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'set')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SET for the initial creation
+        # 2 = a SET for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.set')
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'set')
 
     def test_scenario_new__noTimeout_trigger_pythonNoExpires_noRedisTtl(self):
         """the ``timeout_trigger`` is irrelevant"""
@@ -1351,12 +1379,14 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SET for the initial creation
-        # 1 = a SET for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.set')
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'set')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SET for the initial creation
+        # 2 = a SET for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.set')
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'set')
 
     def test_scenario_new__noTimeout_noTrigger_pythonExpires_noRedisTtl(self):
         session_args = self._args_noTimeout_noTrigger_pythonExpires_noRedisTtl
@@ -1366,12 +1396,14 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SET for the initial creation
-        # 1 = a SET for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.set')
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'set')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SET for the initial creation
+        # 2 = a SET for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.set')
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'set')
 
     def test_scenario_new__noTimeout_noTrigger_noPythonExpires_noRedisTtl(self):
         session_args = self._args_noTimeout_noTrigger_noPythonExpires_noRedisTtl
@@ -1381,12 +1413,14 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
         stored_session_data = self._deserialize_session_stored(request.session)
         self.assertNotIn('x', stored_session_data)
 
-        # there should be two items in the history:
-        # 0 = a pipeline.SET for the initial creation
-        # 1 = a SET for the persist
-        self.assertEqual(len(request.registry._redis_sessions._history), 2)
-        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.set')
-        self.assertEqual(request.registry._redis_sessions._history[1][0], 'set')
+        # there should be three items in the history:
+        # 0 = a pipeline.GET for the initial id
+        # 1 = a pipeline.SET for the initial creation
+        # 2 = a SET for the persist
+        self.assertEqual(len(request.registry._redis_sessions._history), 3)
+        self.assertEqual(request.registry._redis_sessions._history[0][0], 'pipeline.get')
+        self.assertEqual(request.registry._redis_sessions._history[1][0], 'pipeline.set')
+        self.assertEqual(request.registry._redis_sessions._history[2][0], 'set')
 
     # --------------------------------------------------------------------------
     # existing session - timeout
@@ -1443,6 +1477,7 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
     def test_scenario_existing__timeout_noTrigger_noPythonExpires_noRedisTtl_noChange(self):
         """
         a timeout entirely occurs via EXPIRY in redis
+        python -munittest pyramid_session_redis.tests.test_factory.TestRedisSessionFactory_expiries_v1_4_x.test_scenario_existing__timeout_noTrigger_noPythonExpires_noRedisTtl_noChange
         """
         session_args = self._args_timeout_noTrigger_noPythonExpires_noRedisTtl
         request = self._prep_existing_session(session_args)
@@ -1453,6 +1488,9 @@ class TestRedisSessionFactory_expiries_v1_4_x(_TestRedisSessionFactoryCore, _Tes
 
         # there should be 1 items in the history:
         # 0 = a SET for the initial creation
+        # 1 = GET
+        # 2 = GET
+        # print "request.registry._redis_sessions._history", request.registry._redis_sessions._history
         self.assertEqual(len(request.registry._redis_sessions._history), 3)
         self.assertEqual(request.registry._redis_sessions._history[0][0], 'set')
 

--- a/pyramid_session_redis/tests/test_session.py
+++ b/pyramid_session_redis/tests/test_session.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import print_function
+
 
 import itertools
 import pdb
@@ -577,7 +579,7 @@ class TestRedisSession(unittest.TestCase):
         self.assertEqual(inst.from_redis()['t'], adjusted_timeout)
 
 
-class TestRedisSessionNew(unittest.TestCase):
+class _TestRedisSessionNew_SUPPORT(object):
     """these are 1.2x+ tests"""
 
     def _makeOne(self, redis, session_id, new, new_session,
@@ -675,6 +677,10 @@ class TestRedisSessionNew(unittest.TestCase):
         _session_data = session.redis.store[_session_id]
         _session_serialized = deserialize(_session_data)
         return _session_serialized
+
+
+class TestRedisSessionNew(unittest.TestCase, _TestRedisSessionNew_SUPPORT):
+    """these are 1.2x+ tests"""
 
     def test_init_new_session_notimeout(self):
         session_id = 'session_id'
@@ -872,7 +878,7 @@ class TestRedisSessionNew(unittest.TestCase):
             )
 
 
-class TestRedisSessionNewAlt2(TestRedisSessionNew):
+class TestRedisSessionNewAlt2(_TestRedisSessionNew_SUPPORT, unittest.TestCase):
     """these are 1.4x+ tests"""
     PYTHON_EXPIRES = True
     set_redis_ttl = True
@@ -1022,7 +1028,7 @@ class TestRedisSessionNewAlt2(TestRedisSessionNew):
         self.assertEqual(session2_redis['x'], (session2.timestamp + adjusted_timeout))
 
         sleeptime = session2_redis['x'] - int(time.time()) + 1
-        print "sleeping for ", sleeptime
+        print("sleeping for ", sleeptime)
         time.sleep(sleeptime)
 
         with self.assertRaises(InvalidSession_PayloadTimeout):
@@ -1049,7 +1055,8 @@ class TestRedisSessionNewAlt2(TestRedisSessionNew):
         # 8 - GET
         self.assertEqual(len(session.redis._history), 9)
 
-class TestRedisSessionNewAlt3(TestRedisSessionNew):
+
+class TestRedisSessionNewAlt3(_TestRedisSessionNew_SUPPORT, unittest.TestCase):
     """these are 1.4x+ tests"""
     PYTHON_EXPIRES = False
     set_redis_ttl = True
@@ -1124,7 +1131,7 @@ class TestRedisSessionNewAlt3(TestRedisSessionNew):
         
         # will sleep for a moment...
         sleepy = timeout - 1
-        print "will sleep for:", sleepy
+        print("will sleep for:", sleepy)
         time.sleep(sleepy)
 
         session3 = self._makeOne(


### PR DESCRIPTION
work in this branch that solves #16 (an idea brought up in #11)...

GET+EXPIRE are initially done at the beginning of a cache-hit in a pipeline.  if this happens, "dont_refresh" is set and simply viewing a key won't refresh the expiry a second time in the cleanup.

this is controlled by an automated optimization... where we are using a timeout in redis and not python, with no timeout_trigger. viewing a session will always refresh the expiry.



