### PR TITLE
explicit option for redis ttl now required.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@ Changelog
     * version 1.4.2
     * set default timeout trigger to `None` (issue #12, forked from #11)
     * migrated `pyramid_session_redis._finished_callback` into `RedisSession._deferred_callback`
+    * introduced new `set_redis_ttl_readheavy` option for read-intensive deployments
+    
 
 -10/17/2017
     * version 1.4.1


### PR DESCRIPTION
addresses deficiencies in previous attempt to close #16
* cleaning up/centralizing tests
* made the set_redis_ttl_readheavy option on the factory
* made "secret" `_set_redis_ttl_onexit` option on session (to be calculated by factory)
* found some small cases where an expire wouldn't set in redis;  addressed