### PR TITLE
initial idea for samesite support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Changelog
 -2019.09.xx
     * version 1.5.1
     * support for same_site cookies
+    * inline docs improved
+    * configs_bool moved to `utils`, still accessable for now.
 
 -2019.06.27
     * version 1.5.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,9 @@
 Changelog
 =========
 
-- Unreleased
-    * skipped 1.3 release.  not enough usage to warrant backwards compat right now
-    * a bunch of api changes to support lazy-created sessions.  the original structure would immediately create sessions, which can cause issues with bots and spidering.
+-2019.09.xx
+    * version 1.5.1
+    * support for same_site cookies
 
 -2019.06.27
     * version 1.5.0
@@ -32,6 +32,10 @@ Changelog
     * migrated some RedisSessionFactory functions into a more global (not per-request) block
     * added `func_invalid_logger` to session factory, also renamed internal exceptions. they were not a public api so there is no deprecation issue.
     * this seems fine in our production usage, so pushing live.
+
+- Unreleased
+    * skipped 1.3 release.  not enough usage to warrant backwards compat right now
+    * a bunch of api changes to support lazy-created sessions.  the original structure would immediately create sessions, which can cause issues with bots and spidering.
 
 -1/24/2017:
     * version 1.2.2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 IMPORTANT
 =========
 
-`pyramid_session_redis` is an actively maintained fork of `pyramid_redis_sessions` (ericrasmussen/pyramid_redis_sessions), with many improvements and API changes designed for high performance (particularly with servers under load) and a slightly different API for developer convenience.
+`pyramid_session_redis` is an actively maintained fork of `pyramid_redis_sessions` (`ericrasmussen/pyramid_redis_sessions``), with many improvements and API changes designed for high performance (particularly with servers under load) and a slightly different API for developer convenience.
 
 This package is following a multi-version release process.
 
@@ -25,7 +25,7 @@ The 1.4.x branch is under active development and subject to change.  It culminat
 
 The 1.2.x branch and earlier are largely compatible with `pyramid_redis_sessions` as-is.  If you are using this, you should pin your installs to `<=1.3.0` or `<1.3`.
 
-The 1.4.x branch and later have several design changes and are not a drop-in replacement.  Some kwargs may have changed.  The structure of the package has changed as well, and advanced users who leverage the internals will need to upgrade.  The package remains a plug-and-play pyramid sessions interface.
+The 1.4.x branch and later have several design changes and are not a drop-in replacement.  Some kwargs may have changed.  The structure of the package has changed as well, and advanced users who leverage the internals will need to upgrade.  The package remains a plug-and-play Pyramid sessions interface.
 
 IMPORTANT: The internal payload structure has changed in the 1.4 branch, and is no longer compatible with existing 1.2 sessions (they will be invalid).  I am open to PRs that can handle a graceful fallback.
 
@@ -213,22 +213,22 @@ This is a new option in `1.4.2` which should improve performance on readheavy in
 The default behavior of this library during a read-only request is this:
 
 * On session access, query Redis via `redis.GET {session_id}`
-* In a pyramid callback, update Redis via `redis.EXPIRE {session_id} {expiry}`
+* In a Pyramid callback, update Redis via `redis.EXPIRE {session_id} {expiry}`
 
 During a read-write:
 
 * On session access, query Redis via `redis.GET {session_id}`
-* In a pyramid callback, update Redis via `redis.SETEX {session_id} {payload} {expiry}`
+* In a Pyramid callback, update Redis via `redis.SETEX {session_id} {payload} {expiry}`
 
 The new `set_redis_ttl_readheavy` changes this. If enabled, during a read-only request the behavior will be lighter on the Redis instance:
 
 * On session access, open a pipeline with two Redis commands: `pipeline.GET {session_id}`, `pipeline.EXPIRE {session_id} {expiry}`.
-* In a pyramid callback, the duplicate expire is suppressed.
+* In a Pyramid callback, the duplicate expire is suppressed.
 
 However during a read-write, the activity will be:
 
 * On session access, open a pipeline with two Redis commands: `pipeline.GET {session_id}`, `pipeline.EXPIRE {session_id} {expiry}`.
-* In a pyramid callback, update Redis via `redis.SETEX {session_id} {payload} {expiry}`
+* In a Pyramid callback, update Redis via `redis.SETEX {session_id} {payload} {expiry}`
 
 Read-heavy applications should see a slight performance bump via the piplined GET+EXPIRE, however write-heavy applications are likely to see a performance degradation as it adds an extra EXPIRE to every request.
 
@@ -321,13 +321,13 @@ All support is handled via GitHub : https://github.com/jvanasco/pyramid_session_
 ToDo
 =====
 
-pass
+see `TODO.md`
 
 
 Overview
 ========
 
-pyramid_redis_sessions is a server-side session library for the Pyramid Web
+`pyramid_redis_sessions` is a server-side session library for the Pyramid Web
 Application Development Framework, using Redis for storage. This library
 implements the `Pyramid ISession interface <http://docs.pylonsproject.org/projects/pyramid/en/latest/api/interfaces.html#pyramid.interfaces.ISession>`_.
 
@@ -362,17 +362,12 @@ on Read the Docs.
 Support
 =======
 
-You can report bugs or open feature/support requests in the
-`GitHub issue tracker <https://github.com/ericrasmussen/pyramid_redis_sessions/issues>`_.
-
-You can also get live help in #pyramid on irc.freenode.org. My nick is erasmas,
-but if I'm not available you can still typically get support from the many other
-knowledgeable regulars.
+You can report bugs or open feature/support requests via GitHub : https://github.com/jvanasco/pyramid_session_redis
 
 
 License
 =======
 
-pyramid_redis_sessions is available under a FreeBSD-derived license. See
-`LICENSE.txt <https://github.com/ericrasmussen/pyramid_redis_sessions/blob/master/LICENSE.txt>`_
+`pyramid_session_redis` is available under a FreeBSD-derived license. See
+`LICENSE.txt <https://github.com/jvanasco/pyramid_session_redis/blob/master/LICENSE.txt>`_
 for details.

--- a/pyramid_session_redis/__init__.py
+++ b/pyramid_session_redis/__init__.py
@@ -17,20 +17,12 @@ from .util import (
     warn_future,
     empty_session_payload,
     LAZYCREATE_SESSION,
+    configs_bool,  # not used here, but included for legacy
+    configs_dotable,
 )
 
 
 __VERSION__ = "1.5.1"
-
-
-configs_dotable = (
-    "client_callable",
-    "serialize",
-    "deserialize",
-    "id_generator",
-    "func_check_response_allow_cookies",
-    "func_invalid_logger",
-)
 
 
 def check_response_allow_cookies(response):

--- a/pyramid_session_redis/__init__.py
+++ b/pyramid_session_redis/__init__.py
@@ -4,10 +4,7 @@ import functools
 import time
 
 from pyramid.exceptions import ConfigurationError
-from pyramid.session import (
-    signed_deserialize,
-    signed_serialize,
-)
+from pyramid.session import signed_deserialize, signed_serialize
 
 from .compat import pickle
 from .connection import get_default_connection
@@ -23,25 +20,17 @@ from .util import (
 )
 
 
-__VERSION__ = '1.5.1'
+__VERSION__ = "1.5.1"
 
 
-configs_dotable = ('client_callable',
-                   'serialize',
-                   'deserialize',
-                   'id_generator',
-                   'func_check_response_allow_cookies',
-                   'func_invalid_logger',
-                   )
-
-
-configs_bool = ('cookie_on_exception',
-                'cookie_secure',
-                'cookie_httponly',
-                'assume_redis_lru',
-                'detect_changes',
-                'deserialized_fails_new',
-                )
+configs_dotable = (
+    "client_callable",
+    "serialize",
+    "deserialize",
+    "id_generator",
+    "func_check_response_allow_cookies",
+    "func_invalid_logger",
+)
 
 
 def check_response_allow_cookies(response):
@@ -55,7 +44,7 @@ def check_response_allow_cookies(response):
     """
     # The view signals this is cacheable response
     # and we should not stamp a session cookie on it
-    cookieless_headers = ["expires", "cache-control", ]
+    cookieless_headers = ["expires", "cache-control"]
     for header in cookieless_headers:
         if header in response.headers:
             return False
@@ -78,7 +67,7 @@ def includeme(config):
 
     # special rule for converting dotted python paths to callables
     for option in configs_dotable:
-        key = 'redis.sessions.%s' % option
+        key = "redis.sessions.%s" % option
         if key in settings:
             settings[key] = config.maybe_dotted(settings[key])
     session_factory = session_factory_from_settings(settings)
@@ -104,9 +93,9 @@ def session_factory_from_settings(settings):
 def RedisSessionFactory(
     secret,
     timeout=1200,
-    cookie_name='session',
+    cookie_name="session",
     cookie_max_age=None,
-    cookie_path='/',
+    cookie_path="/",
     cookie_domain=None,
     cookie_secure=False,
     cookie_httponly=True,
@@ -114,15 +103,10 @@ def RedisSessionFactory(
     cookie_samesite=None,
     cookie_on_exception=True,
     url=None,
-    host='localhost',
+    host="localhost",
     port=6379,
     db=0,
     password=None,
-    socket_timeout=None,
-    connection_pool=None,
-    charset='utf-8',
-    errors='strict',
-    unix_socket_path=None,
     client_callable=None,
     serialize=pickle.dumps,
     deserialize=pickle.loads,
@@ -135,6 +119,11 @@ def RedisSessionFactory(
     func_invalid_logger=None,
     timeout_trigger=None,
     python_expires=True,
+    socket_timeout=None,
+    connection_pool=None,
+    charset="utf-8",
+    errors="strict",
+    unix_socket_path=None,
 ):
     """
     Constructs and returns a session factory that will provide session data
@@ -174,119 +163,153 @@ def RedisSessionFactory(
     framework as ``domain``.
 
     ``cookie_secure``
-    The 'secure' flag of the session cookie. Default: ``False``.
+    Boolean value; Default: ``False``.
+    The 'secure' flag of the session cookie.
     This is passed on to the underlying ``WebOb.response.Response.set_cookie``
     framework as ``secure``.
 
     ``cookie_httponly``
-    The 'httpOnly' flag of the session cookie. Default: ``True``.
+    Boolean value; Default: ``True``.
+    The 'httpOnly' flag of the session cookie.
     This is passed on to the underlying ``WebOb.response.Response.set_cookie``
     framework as ``httponly``.
 
     ``cookie_comment``
-    The 'comment' attribute of the session cookie.  Default: ``None```
+    Default: ``None``.
+    The 'comment' attribute of the session cookie.
     This is paseed on to the underlying ``WebOb.response.Response.set_cookie``
     framework as ``comment``.
     If set to ``None`` or not specified, it will not be passed on.
 
     ``cookie_samesite``
-    The 'SameSite' attribute of the session cookie.  Default: ``None```
+    Default: ``None``.
+    The 'SameSite' attribute of the session cookie.
     This is paseed on to the underlying ``WebOb.response.Response.set_cookie``
     framework as ``samesite`` and **requires WebOb 1.8.0 or higher**.
     If set to ``None`` or not specified, it will not be passed on.
     Should only be ``"Strict"`` or ``"Lax"``.
 
     ``cookie_on_exception``
+    Boolean value; Default: ``True``.
     If ``True``, set a session cookie even if an exception occurs
-    while rendering a view. Default: ``True``.
+    while rendering a view.
 
     ``url``
+    Default: ``None``.
     A connection string for a Redis server, in the format:
     redis://username:password@localhost:6379/0
-    Default: ``None``.
 
     ``host``
-    A string representing the IP of your Redis server. Default: ``localhost``.
+    Default: ``localhost``.
+    A string representing the IP of your Redis server.
 
     ``port``
-    An integer representing the port of your Redis server. Default: ``6379``.
+    Default: ``6379``.
+    An integer representing the port of your Redis server.
 
     ``db``
+    Integer value; Default: ``0``
     An integer to select a specific database on your Redis server.
-    Default: ``0``
 
     ``password``
+    Default: ``None``.
     A string password to connect to your Redis server/database if
-    required. Default: ``None``.
-
+    required.
+    
     ``client_callable``
+    Default: ``None``.
     A python callable that accepts a Pyramid `request` and Redis config options
     and returns a Redis client such as redis-py's `StrictRedis`.
-    Default: ``None``.
 
     ``serialize``
-    A function to serialize the session dict for storage in Redis.
     Default: ``pickle.dumps``. PY2=cPickle
+    A function to serialize the session dict for storage in Redis.
 
     ``deserialize``
-    A function to deserialize the stored session data in Redis.
     Default: ``pickle.loads``. PY2=cPickle
+    A function to deserialize the stored session data in Redis.
 
     ``id_generator``
-    A function to create a unique ID to be used as the session key when a
-    session is first created.
     Default: private function that uses sha1 with the time and random elements
     to create a 40 character unique ID.
+    A function to create a unique ID to be used as the session key when a
+    session is first created.
 
     ``set_redis_ttl``
-    Boolean value.  Default `True`. If set to ``True``, will set a TTL. If
+    Boolean value;  Default `True`.
+    If set to ``True``, will set a TTL. If
     ``False`` will not set a TTL and assumes that Redis is configured as a
     least-recently-used cache [http://redis.io/topics/lru-cache] and will NOT
     send EXPIRY data of sessions to Redis (the value of `timeout` will be
     ignored if set). This does not require or imply that no ``timeout`` data is
     handled within the Python payload, it just determines if Redis will be
     involved with timeout logic.
-    Default: ``False``
 
     ``set_redis_ttl_readheavy``
-     If ``True``, sets TTL data in Redis within a PIPELINE via GET+EXPIRE and
-     supresses automatic TTL refresh during the deferred cleanup phase. If not 
-     ``True``, an EXPIRE is sent as a separate action during the deferred
-     cleanup phase.  The optimized behavior improves performance on read-heavy
-     operations, but may degrade performance on write-heavy operations.  This
-     requires a ``timeout`` and ``set_redis_ttl`` to be True; it is not
+     Boolean value; Default: ``None``.
+     If ``True``, sets TTL data in Redis within
+     a PIPELINE via GET+EXPIRE and supresses automatic TTL refresh during the deferred
+     cleanup phase. If not ``True``, an EXPIRE is sent as a separate action during
+     the deferred cleanup phase.  The optimized behavior improves performance on
+     read-heavy operations, but may degrade performance on write-heavy operations.
+     This requires a ``timeout`` and ``set_redis_ttl`` to be True; it is not
      compatible with ``timeout_trigger`` or ``python_expires``.
-     Default: ``None``
 
     ``detect_changes``
-    Boolean value. If set to ``True``, will calculate nested changes after
+    Boolean value; Default: ``True``.
+    If set to ``True``, will calculate nested changes after
     serialization to ensure persistence of nested data.
-    Default: ``True``
 
     ``deserialized_fails_new``
-    If ``True`` will handle deserializtion errors by creating a new session.
+    Boolean value; Default: ``None``.
+    If ``True`` will handle deserializtion errors
+    by creating a new session.
 
     ``func_check_response_allow_cookies``
+    Default: ``None``.
     A callable function that accepts a response, returning ``True`` if the
-    cookie can be sent and ``False`` if it should not.  This defaults to
-    ``None``.  An example callable is available in
+    cookie can be sent and ``False`` if it should not. 
+     An example callable is available in
     ``check_response_allow_cookies``, which checks for `expires` and
     `cache-control` cookies.
 
-    ``python_expires``
-    Int, default ``True``.  If ``True``, allows for timeout logic to be tracked
-    in Python
-
     ``func_invalid_logger``
+    Default: ``None``.
     A callable function that expects a single argument of a raised
     `InvalidSession` exception. If not ``None``, this will be called so your
     application can monitor.
 
     ``timeout_trigger``
-    Int, default  ``None``.  If unset or ``0``, timeouts will be updated on
+    Integer value; Default ``None``.
+    If unset or ``0``, timeouts will be updated on
     every access by setting an EXPIRY in Redis and/or updating the ``expires``
     value in the  session payload.  If set to an INT, the updates will only be
     set once the threshold is crossed.
+
+    ``python_expires``
+    Boolean value; Default ``True``.
+    If ``True``, allows for timeout logic to be
+    tracked in Python.
+
+    ``socket_timeout``
+    Default: ``None``.
+    Passthrough argument to the `StrictRedis` constructor.
+
+    ``connection_pool``
+    Default: ``None``.
+    Passthrough argument to the `StrictRedis` constructor.
+
+    ``charset``
+    Default: ``utf-8``.
+    Passthrough argument to the `StrictRedis` constructor.
+
+    ``errors``
+    Default: ``strict``.
+    Passthrough argument to the `StrictRedis` constructor.
+
+    ``unix_socket_path``
+    Default: ``None``.
+    Passthrough argument to the `StrictRedis` constructor.
 
     Given this example:
 
@@ -311,7 +334,7 @@ def RedisSessionFactory(
     user leaves the site at 49 minutes and returns at 61 minutes, the trigger
     will not have been made and the session will have expired.
 
-    The following arguments are also passed straight to the ``StrictRedis``
+    The following arguments are passed straight to the ``StrictRedis``
     constructor and allow you to further configure the Redis client::
 
       socket_timeout
@@ -329,26 +352,33 @@ def RedisSessionFactory(
     # optimize a `TTL refresh` under certain conditions
     if set_redis_ttl_readheavy:
         if (not timeout) or (not set_redis_ttl):
-            raise ValueError("`set_redis_ttl_readheavy` requires a `timeout` and `set_redis_ttl`")
+            raise ValueError(
+                "`set_redis_ttl_readheavy` requires a `timeout` and `set_redis_ttl`"
+            )
         if timeout_trigger or python_expires:
-            raise ValueError("`set_redis_ttl_readheavy` is not compatible with `timeout_trigger` and `python_expires`")
+            raise ValueError(
+                "`set_redis_ttl_readheavy` is not compatible with `timeout_trigger` and `python_expires`"
+            )
     optimize_redis_ttl = False
-    
+
     _set_redis_ttl_onexit = False
-    if (timeout and set_redis_ttl) and (not timeout_trigger and not python_expires and not set_redis_ttl_readheavy):
+    if (timeout and set_redis_ttl) and (
+        not timeout_trigger and not python_expires and not set_redis_ttl_readheavy
+    ):
         _set_redis_ttl_onexit = True
 
     # good for all factory() requests
-    set_cookie_kwargs = {'max_age': cookie_max_age,
-                          'path': cookie_path,
-                          'domain': cookie_domain,
-                          'secure': cookie_secure,
-                          'httponly': cookie_httponly,
-                          }
+    set_cookie_kwargs = {
+        "max_age": cookie_max_age,
+        "path": cookie_path,
+        "domain": cookie_domain,
+        "secure": cookie_secure,
+        "httponly": cookie_httponly,
+    }
     if cookie_comment is not None:
-        set_cookie_kwargs['comment'] = cookie_comment
+        set_cookie_kwargs["comment"] = cookie_comment
     if cookie_samesite is not None:
-        set_cookie_kwargs['samesite'] = cookie_samesite
+        set_cookie_kwargs["samesite"] = cookie_samesite
 
     # good for all factory() requests
     redis_options = dict(
@@ -365,9 +395,7 @@ def RedisSessionFactory(
 
     # good for all factory() requests
     new_payload_func = functools.partial(
-        empty_session_payload,
-        timeout=timeout,
-        python_expires=python_expires,
+        empty_session_payload, timeout=timeout, python_expires=python_expires
     )
 
     # good for all factory() requests
@@ -381,9 +409,11 @@ def RedisSessionFactory(
     def factory(request, new_session_id_func=create_unique_session_id):
 
         # an explicit client callable gets priority over the default
-        redis_conn = client_callable(request, **redis_options) \
-            if client_callable is not None \
+        redis_conn = (
+            client_callable(request, **redis_options)
+            if client_callable is not None
             else get_default_connection(request, url=url, **redis_options)
+        )
 
         new_session_func = functools.partial(
             new_session_id_func,
@@ -401,12 +431,10 @@ def RedisSessionFactory(
         try:
             # attempt to retrieve a session_id from the cookie
             session_id = _get_session_id_from_cookie(
-                request=request,
-                cookie_name=cookie_name,
-                secret=secret,
+                request=request, cookie_name=cookie_name, secret=secret
             )
             if not session_id:
-                raise InvalidSession_NoSessionCookie('No `session_id` in cookie.')
+                raise InvalidSession_NoSessionCookie("No `session_id` in cookie.")
             session_cookie_was_valid = True
             session = RedisSession(
                 redis=redis_conn,
@@ -489,24 +517,13 @@ def _get_session_id_from_cookie(request, cookie_name, secret):
     return None
 
 
-def _set_cookie(
-    session,
-    request,
-    response,
-    secret,
-    cookie_name,
-    **kwargs
-):
+def _set_cookie(session, request, response, secret, cookie_name, **kwargs):
     """
     `session` is via functools.partial
     `request` and `response` are appended by add_response_callback
     """
     cookieval = signed_serialize(session.session_id, secret)
-    response.set_cookie(
-        cookie_name,
-        cookieval,
-        **kwargs
-    )
+    response.set_cookie(cookie_name, cookieval, **kwargs)
 
 
 def _delete_cookie(response, cookie_name, cookie_path, cookie_domain):
@@ -549,7 +566,7 @@ def _cookie_callback(
             # web servicess do not serve this response from a cache
             # for requests coming in with a different session cookie.
             # Otherwise we might leak sessions between users.
-            varies = ("Cookie", )
+            varies = ("Cookie",)
             vary = set(response.vary if response.vary is not None else [])
             vary |= set(varies)
             response.vary = vary

--- a/pyramid_session_redis/__init__.py
+++ b/pyramid_session_redis/__init__.py
@@ -339,6 +339,18 @@ def RedisSessionFactory(
         _set_redis_ttl_onexit = True
 
     # good for all factory() requests
+    set_cookie_kwargs = {'max_age': cookie_max_age,
+                          'path': cookie_path,
+                          'domain': cookie_domain,
+                          'secure': cookie_secure,
+                          'httponly': cookie_httponly,
+                          }
+    if cookie_comment is not None:
+        set_cookie_kwargs['comment'] = cookie_comment
+    if cookie_samesite is not None:
+        set_cookie_kwargs['samesite'] = cookie_samesite
+
+    # good for all factory() requests
     redis_options = dict(
         host=host,
         port=port,
@@ -436,22 +448,12 @@ def RedisSessionFactory(
                 python_expires=python_expires,
             )
 
-        _set_cookie_kwargs = {'max_age': cookie_max_age,
-                              'path': cookie_path,
-                              'domain': cookie_domain,
-                              'secure': cookie_secure,
-                              'httponly': cookie_httponly,
-                              }
-        if cookie_comment is not None:
-            _set_cookie_kwargs['comment'] = cookie_comment
-        if cookie_samesite is not None:
-            _set_cookie_kwargs['samesite'] = cookie_samesite
         set_cookie_func = functools.partial(
             _set_cookie,
             session,
             secret=secret,
             cookie_name=cookie_name,
-            **_set_cookie_kwargs
+            **set_cookie_kwargs
         )
         cookie_callback = functools.partial(
             _cookie_callback,
@@ -493,7 +495,7 @@ def _set_cookie(
     response,
     secret,
     cookie_name,
-    **_set_cookie_kwargs
+    **kwargs
 ):
     """
     `session` is via functools.partial
@@ -503,7 +505,7 @@ def _set_cookie(
     response.set_cookie(
         cookie_name,
         cookieval,
-        **_set_cookie_kwargs
+        **kwargs
     )
 
 

--- a/pyramid_session_redis/tests/test_factory.py
+++ b/pyramid_session_redis/tests/test_factory.py
@@ -146,6 +146,8 @@ class TestRedisSessionFactory(_TestRedisSessionFactoryCore):
         cookie_domain = 'example.com'
         cookie_secure = True
         cookie_httponly = False
+        cookie_comment = None  # TODO: QA
+        cookie_samesite = None  # TODO: QA
         secret = 'test secret'
 
         request = self._make_request()
@@ -157,6 +159,8 @@ class TestRedisSessionFactory(_TestRedisSessionFactoryCore):
             cookie_domain=cookie_domain,
             cookie_secure=cookie_secure,
             cookie_httponly=cookie_httponly,
+            cookie_comment=cookie_comment,
+            cookie_samesite=cookie_samesite,
             secret=secret,
         )
         session['key'] = 'value'
@@ -179,6 +183,8 @@ class TestRedisSessionFactory(_TestRedisSessionFactoryCore):
             domain=cookie_domain,
             secure=cookie_secure,
             httponly=cookie_httponly,
+            comment=cookie_comment,
+            samesite=cookie_samesite,
         )
         expected_header = response_to_check_against.headers.getall(
             'Set-Cookie')[0]

--- a/pyramid_session_redis/util.py
+++ b/pyramid_session_redis/util.py
@@ -76,6 +76,40 @@ def _generate_session_id():
     return token_urlsafe(48)
 
 
+# ---------------------
+
+# `_parse_settings` and `includeme` may need to coerce strings into other types
+# these lists are maintained here as a public API, so implementers who need
+# to customize their integration can do so without fear of breaking changes
+
+configs_dotable = (
+    "client_callable",
+    "serialize",
+    "deserialize",
+    "id_generator",
+    "func_check_response_allow_cookies",
+    "func_invalid_logger",
+)
+
+configs_bool = (
+    "cookie_secure",
+    "cookie_httponly",
+    "cookie_on_exception",
+    "set_redis_ttl",
+    "set_redis_ttl_readheavy",
+    "detect_changes",
+    "deserialized_fails_new",
+    "python_expires",
+)
+
+configs_int = ("port", "db", "cookie_max_age")
+
+configs_int_none = ("timeout", "timeout_trigger")
+
+
+# ---------------------
+
+
 def prefixed_id(prefix="session:"):
     """
     Adds a prefix to the unique session id, for cases where you want to
@@ -237,26 +271,17 @@ def _parse_settings(settings):
         raise ConfigurationError("redis.sessions.secret is a required setting")
 
     # coerce bools
-    for b in (
-        "cookie_secure",
-        "cookie_httponly",
-        "cookie_on_exception",
-        "set_redis_ttl",
-        "set_redis_ttl_readheavy",
-        "detect_changes",
-        "deserialized_fails_new",
-        "python_expires",
-    ):
+    for b in configs_bool:
         if b in options:
             options[b] = asbool(options[b])
 
     # coerce ints
-    for i in ("port", "db", "cookie_max_age"):
+    for i in configs_int:
         if i in options:
             options[i] = int(options[i])
 
     # allow "None" to be a value for some ints
-    for i in ("timeout", "timeout_trigger"):
+    for i in configs_int_none:
         if i in options:
             if options[i] == "None":
                 options[i] = None

--- a/setup.py
+++ b/setup.py
@@ -9,68 +9,67 @@ from setuptools import setup
 # manage package version
 # store version in the init.py
 with open(
-        os.path.join(
-            os.path.dirname(__file__),
-            'pyramid_session_redis', '__init__.py')) as v_file:
-    package_version = re.compile(
-        r".*__VERSION__ = '(.*?)'",
-        re.S).match(v_file.read()).group(1)
+    os.path.join(os.path.dirname(__file__), "pyramid_session_redis", "__init__.py")
+) as v_file:
+    package_version = (
+        re.compile(r'.*__VERSION__ = "(.*?)"', re.S).match(v_file.read()).group(1)
+    )
 
 
 # get readme and changes
 here = os.path.abspath(os.path.dirname(__file__))
 try:
-    with open(os.path.join(here, 'README.md')) as text_file:
+    with open(os.path.join(here, "README.md")) as text_file:
         README = text_file.read()
-    with open(os.path.join(here, 'CHANGES.md')) as text_file:
+    with open(os.path.join(here, "CHANGES.md")) as text_file:
         CHANGES = text_file.read()
 except IOError:
-    README = CHANGES = ''
+    README = CHANGES = ""
 
 # set up requires
-install_requires = ['redis>=2.4.11, != 2.9.1',
-                    'pyramid>=1.3,<2',
-                    'six',
-                    # 'zope.interface',  # in Pyramid
-                    ]
-testing_requires = ['nose',
-                    # 'webob',  # in Pyramid
-                    ]
-testing_extras = testing_requires + ['coverage']
-docs_extras = ['sphinx']
+install_requires = [
+    "redis>=2.4.11, != 2.9.1",
+    "pyramid>=1.3,<2",
+    "six",
+    # 'zope.interface',  # in Pyramid
+]
+testing_requires = [
+    "nose",
+    # 'webob',  # in Pyramid
+]
+testing_extras = testing_requires + ["coverage"]
+docs_extras = ["sphinx"]
 
 
 def main():
 
     setup(
-        name='pyramid_session_redis',
+        name="pyramid_session_redis",
         version=package_version,
-        description='Pyramid web framework session factory backed by Redis',
-        long_description=README + '\n\n' + CHANGES,
+        description="Pyramid web framework session factory backed by Redis",
+        long_description=README + "\n\n" + CHANGES,
         classifiers=[
-            'Intended Audience :: Developers',
+            "Intended Audience :: Developers",
             "Framework :: Pyramid",
             "Programming Language :: Python :: 2.7",
             "Programming Language :: Python :: 3",
-            ],
-        keywords='pyramid session redis',
-        author='Jonathan Vanasco',
-        author_email='jonathan@findmeon.com',
-        url='https://github.com/jvanasco/pyramid_session_redis',
-        license='FreeBSD',
+        ],
+        keywords="pyramid session redis",
+        author="Jonathan Vanasco",
+        author_email="jonathan@findmeon.com",
+        url="https://github.com/jvanasco/pyramid_session_redis",
+        license="FreeBSD",
         packages=find_packages(),
-        #test_suite='pyramid_session_redis.tests.test_factory.TestRedisSessionFactory_loggedExceptions',
-        test_suite='nose.collector',
+        # test_suite='pyramid_session_redis.tests.test_factory.TestRedisSessionFactory_loggedExceptions',
+        test_suite="nose.collector",
         include_package_data=True,
         zip_safe=False,
         tests_require=testing_requires,
         install_requires=install_requires,
-        entry_points='',
-        extras_require = {
-            'testing': testing_extras,
-            'docs': docs_extras,
-            },
+        entry_points="",
+        extras_require={"testing": testing_extras, "docs": docs_extras},
     )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
this PR is just a quick sketch for handling #22

* clarify what is passed on to webob
* support for `samesite` and `comment`
* to better support backwards compatibility, cast the elements into a dict and only include the intended args. this is only done during factory setup, although the ``**kwargs`` happens per request.