### PR TITLE
Add support for Pyramid 2.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,6 +16,13 @@ jobs:
     strategy:
       matrix:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        pyramid-version: ["<2", ">=2"]
+        exclude:
+          # Pyramid 2 doesn't support Python 2.7 or 3.5
+          - python-version: 2.7
+            pyramid-version: ">=2"
+          - python-version: 3.5
+            pyramid-version: ">=2"
 
     # Service containers to run with `container-job`
     services:
@@ -39,8 +46,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --upgrade tox setuptools flake8 pytest
+        pip install ".[testing]" "pyramid${{ matrix.pyramid-version }}"
         pip list
     - name: Test with pytest
       run: |
-        tox -e py -- ${{ matrix.pytest-args }}
+        # Python 3.5 needs PYTHONHASHSEED to succeed.
+        PYTHONHASHSEED='3963681585' pytest

--- a/pyramid_session_redis/legacy.py
+++ b/pyramid_session_redis/legacy.py
@@ -16,12 +16,20 @@ import hashlib
 import hmac
 
 # pyramid
-from pyramid.compat import bytes_, native_
 from pyramid.util import strings_differ
 from webob.cookies import SignedSerializer
 
 # pypi
 from six.moves import cPickle as pickle
+from six import ensure_binary, ensure_str
+
+
+def bytes_(s, encoding='latin-1', errors='strict'):
+    return ensure_binary(s, encoding, errors)
+
+
+def native_(s, encoding='latin-1', errors='strict'):
+    return ensure_str(s, encoding, errors)
 
 
 # ==============================================================================

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(HERE, "README.md")) as f:
 # set up requires
 install_requires = [
     "redis>=2.4.11, != 2.9.1",
-    "pyramid>=1.3,<2",
+    "pyramid>=1.3",
     "six",
     "zope.interface",  # in Pyramid
 ]


### PR DESCRIPTION
Sorry to barge in here, I saw your message in the mailing list and figure there must be some way to have our cake and eat it to.  This PR adds support for Pyramid 2, while maintaining support for Pyramid 1 and Python 2.  (Obviously Python 2 and Pyramid 2 don't work together.)  Should work seamlessly for all existing users.

I stopped using tox in GitHub Actions, since Actions handles the test matrix for us and I honestly couldn't figure out how to use it.