### PR TITLE
cookie_expires default is wrong

### DIFF
--- a/src/pyramid_session_redis/__init__.py
+++ b/src/pyramid_session_redis/__init__.py
@@ -98,7 +98,7 @@ def RedisSessionFactory(
     cookie_domain=None,
     cookie_secure=False,
     cookie_httponly=True,
-    cookie_expires=True,
+    cookie_expires=None,
     cookie_comment=None,
     cookie_samesite=None,
     cookie_on_exception=True,


### PR DESCRIPTION
Typo I guess, but it's impactful. :)