### PR TITLE
* prep for 1.6.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Changelog
 			RedisSessionFactory().
 		* add tests for old and new encoding kwargs
 			Add tests for old and new encoding args for RedisSessionFactory()
+	* add tests for incompatible kwargs (test_session_factory_incompatible_kwargs)
 
 
 -2021.04.01

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,19 @@ Changelog
 
 - unreleased
 
+-2021.08.10
+	* version 1.6.2
+	* support newer redis arguments and a `redis_` namespace. thank you, @natej:
+		* Accept newer encoding and encoding_errors args
+			Update RedisSessionFactory() so it accepts newer encoding and
+			encoding_errors args while retaining backwards compatibility.
+		* add redis_ prefix for redis passthrough kwargs
+			Add redis_ prefix for redis passthrough kwargs to
+			RedisSessionFactory().
+		* add tests for old and new encoding kwargs
+			Add tests for old and new encoding args for RedisSessionFactory()
+
+
 -2021.04.01
 	* version 1.6.1
 	* fix invalid `expires` default. thank you, @olemoign

--- a/src/pyramid_session_redis/__init__.py
+++ b/src/pyramid_session_redis/__init__.py
@@ -438,7 +438,7 @@ def RedisSessionFactory(
     if socket_timeout is not None:
         if redis_socket_timeout:
             raise ValueError(
-                "Submit only one of `socket_timeout`, `redis_socket_timeout`"
+                "Submit only one of `redis_socket_timeout`, `socket_timeout`"
             )
         warn_future(
             "`socket_timeout` has been deprecated in favor of `redis_socket_timeout`"
@@ -446,23 +446,23 @@ def RedisSessionFactory(
     if connection_pool is not None:
         if redis_connection_pool:
             raise ValueError(
-                "Submit only one of `connection_pool`, `redis_connection_pool`"
+                "Submit only one of `redis_connection_pool`, `connection_pool`"
             )
         warn_future(
             "`connection_pool` has been deprecated in favor of `redis_connection_pool`"
         )
     if charset is not None:
         if redis_encoding:
-            raise ValueError("Submit only one of `charset`, `redis_encoding`")
+            raise ValueError("Submit only one of `redis_encoding`, `charset`")
         warn_future("`charset` has been deprecated in favor of `redis_encoding`")
     if errors is not None:
         if redis_encoding_errors:
-            raise ValueError("Submit only one of `errors`, `redis_encoding_errors`")
+            raise ValueError("Submit only one of `redis_encoding_errors`, `errors`")
         warn_future("`errors` has been deprecated in favor of `redis_encoding_errors`")
     if unix_socket_path is not None:
         if redis_unix_socket_path:
             raise ValueError(
-                "Submit only one of `unix_socket_path`, `redis_unix_socket_path`"
+                "Submit only one of `redis_unix_socket_path`, `unix_socket_path`"
             )
         warn_future(
             "`unix_socket_path` has been deprecated in favor of `redis_unix_socket_path`"

--- a/src/pyramid_session_redis/session.py
+++ b/src/pyramid_session_redis/session.py
@@ -33,7 +33,6 @@ from .util import (
     recookie,
     refresh,
     SESSION_API_VERSION,
-    warn_future,
 )
 from .util import encode_session_payload as encode_session_payload_func
 from .util import decode_session_payload as decode_session_payload_func

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -717,6 +717,30 @@ class TestRedisSessionFactory(_TestRedisSessionFactoryCore):
         session_using_new = session_factory_from_settings(settings_new)
         assert session_using_new
 
+    def test_session_factory_incompatible_kwargs(self):
+        # incompatible args should raise a ValueError
+        _test_matrix = (
+            ("redis_socket_timeout", "socket_timeout", 1),
+            ("redis_connection_pool", "connection_pool", 1),
+            ("redis_encoding", "charset", "ascii"),
+            ("redis_encoding_errors", "errors", "ascii"),
+            ("redis_unix_socket_path", "unix_socket_path", "/path/to"),
+        )
+        for _set in _test_matrix:
+            with self.assertRaises(ValueError) as cm_expected_exception:
+                _settings = {
+                    "redis.sessions.secret": "secret",  # required
+                    "redis.sessions.%s" % _set[0]: _set[2],
+                    "redis.sessions.%s" % _set[1]: _set[2],
+                }
+                session_using_old = session_factory_from_settings(_settings)
+            exception_wrapper = cm_expected_exception.exception
+            wrapped_exception = exception_wrapper.args[0]
+            assert wrapped_exception == "Submit only one of `%s`, `%s`" % (
+                _set[0],
+                _set[1],
+            )
+
     def test_check_response(self):
         factory = RedisSessionFactory(
             "secret", func_check_response_allow_cookies=check_response_allow_cookies

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -703,8 +703,8 @@ class TestRedisSessionFactory(_TestRedisSessionFactoryCore):
     def test_session_factory_from_settings_redis_encodings(self):
         settings_old = {
             "redis.sessions.secret": "secret",
-            "redis.sessions.redis_charset": "ascii",
-            "redis.sessions.redis_errors": "replace",
+            "redis.sessions.charset": "ascii",
+            "redis.sessions.errors": "replace",
         }
         session_using_old = session_factory_from_settings(settings_old)
         assert session_using_old


### PR DESCRIPTION
* reintroducted legacy redis kwargs for backwards compatibilty
* emit warnings when legacy redis kwargs are used
* raise ValueError when equivalent legacy and modern redis kwargs are used