### PR TITLE
Fix empty session

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,6 +43,9 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          # Maps port 6379 on service container to the host
+          - 6379:6379
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Compatibility
 
 `main` and `1.7` branches require:
 
-* Python 3.6+
+* Python 3.7+
 * Pyramid 2.0
 
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,5 +4,8 @@ ignore_missing_imports = True
 [mypy-webob.*]
 ignore_missing_imports = True
 
+[mypy-webtest.*]
+ignore_missing_imports = True
+
 [mypy-zope.interface.*]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,9 @@ per-file-ignores =
 	src/pyramid_session_redis/session.py: E501
 	src/pyramid_session_redis/util.py: E501
 	tests/test_factory.py: E501,E731
+    tests/test_pyramid.py: E501
 	tests/test_serializers.py: E501
 	tests/test_session.py: E501,E731
 	tests/test_support.py: E501
 	tests/test_util.py: E731
+	tests/web_app.py: E501

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ testing_requires = [
     "nose",
     "pytest",
     "webob",  # in Pyramid
+    "webtest",
+    "waitress",
 ]
 testing_extras = install_requires + testing_requires + ["coverage"]
 docs_extras = [

--- a/src/pyramid_session_redis/__init__.py
+++ b/src/pyramid_session_redis/__init__.py
@@ -114,7 +114,7 @@ def session_factory_from_settings(settings: dict) -> Callable:
 
 
 def RedisSessionFactory(
-    secret: str,
+    secret: Optional[str] = None,  # alternate is `cookie_signer`
     timeout: Optional[int] = 1200,
     cookie_name: str = "session",
     cookie_max_age: Optional[int] = None,
@@ -143,7 +143,7 @@ def RedisSessionFactory(
     func_invalid_logger: Optional[Callable] = None,
     timeout_trigger: Optional[int] = None,
     python_expires: bool = True,
-    cookie_signer: Optional[SerializerInterface] = None,
+    cookie_signer: Optional[SerializerInterface] = None,  # alternate for `secret`
     socket_timeout: Optional[int] = None,  # redis, deprecated
     connection_pool: Optional["ConnectionPool"] = None,  # redis, deprecated
     charset: Optional[str] = None,  # redis, deprecated
@@ -594,6 +594,8 @@ def RedisSessionFactory(
             serializer=_NullSerializer(),  # convert to a string
         )
     else:
+        if TYPE_CHECKING:
+            assert cookie_signer is not None
         _cookie_signer = cookie_signer
 
     def factory(

--- a/src/pyramid_session_redis/legacy.py
+++ b/src/pyramid_session_redis/legacy.py
@@ -31,10 +31,10 @@ from types import ModuleType
 from typing import Any
 from typing import AnyStr
 from typing import Optional
-from typing import Type
 
 # pypi
 from pyramid.util import strings_differ
+from typing_extensions import Protocol
 from webob.cookies import SignedSerializer
 
 # local
@@ -172,6 +172,13 @@ class LegacyCookieSerializer(object):
         return signed_serialize(data, self.secret)
 
 
+class LoggingHookInterface(Protocol):
+
+    def attempt(self, value: str) -> None: ...
+
+    def success(self, value: str) -> None: ...
+
+
 class GracefulCookieSerializer(object):
     """
     `GracefulCookieSerializer` is designed to help developers migrate sessions
@@ -197,12 +204,12 @@ class GracefulCookieSerializer(object):
     secret: bytes
     serializer_current: SignedSerializer  # has .dumps/.loads
     serializer_legacy: LegacyCookieSerializer  # has .dumps/.loads
-    logging_hook: Optional[Type]  # has .attempt, .success
+    logging_hook: Optional[LoggingHookInterface]  # has .attempt, .success
 
     def __init__(
         self,
         secret: AnyStr,
-        logging_hook: Optional[Type] = None,
+        logging_hook: Optional[LoggingHookInterface] = None,
     ):
         """
         :param secret: string. the secret

--- a/src/pyramid_session_redis/session.py
+++ b/src/pyramid_session_redis/session.py
@@ -10,6 +10,7 @@ from typing import Callable
 from typing import Iterator
 from typing import List
 from typing import Optional
+from typing import overload
 from typing import Tuple
 from typing import TYPE_CHECKING
 from typing import Union
@@ -17,6 +18,7 @@ from typing import Union
 # pypi
 from pyramid.decorator import reify
 from pyramid.interfaces import ISession
+from typing_extensions import Literal
 from zope.interface import implementer
 
 # local
@@ -41,13 +43,6 @@ from .util import TYPING_COOKIE_EXPIRES__A
 from .util import TYPING_COOKIE_MAX_AGE__A
 from .util import TYPING_KEY
 from .util import TYPING_SESSION_ID
-
-
-# typing
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore[assignment]
 
 if TYPE_CHECKING:
     from collections.abc import ItemsView
@@ -452,11 +447,32 @@ class RedisSession(object):
         )
         return self.serialize(data)
 
+    @overload
+    def from_redis(  # noqa: E704
+        self,
+        session_id: Optional[TYPING_SESSION_ID] = None,
+        persisted_hash: Optional[None] = None,
+    ) -> dict: ...
+
+    @overload
+    def from_redis(  # noqa: E704
+        self,
+        session_id: Optional[TYPING_SESSION_ID] = None,
+        persisted_hash: Literal[False] = False,
+    ) -> Tuple[dict, None]: ...
+
+    @overload
+    def from_redis(  # noqa: E704
+        self,
+        session_id: Optional[TYPING_SESSION_ID] = None,
+        persisted_hash: Literal[True] = True,
+    ) -> Tuple[dict, str]: ...
+
     def from_redis(
         self,
         session_id: Optional[TYPING_SESSION_ID] = None,
-        persisted_hash: Optional[bool] = None,
-    ) -> Union[dict, Tuple[dict, Union[str, None]]]:
+        persisted_hash: Optional[Literal[True, False]] = None,
+    ):
         """
         Get and deserialize the persisted data for this session from Redis.
         If ``persisted_hash`` is ``None`` (default), returns a single

--- a/src/pyramid_session_redis/util.py
+++ b/src/pyramid_session_redis/util.py
@@ -183,8 +183,8 @@ def empty_session_payload(
 def encode_session_payload(
     managed_dict: dict,
     created: int,
-    timeout: int,
-    expires: int,
+    timeout: int,  # = 0?
+    expires: int,  # = 0?
     timeout_trigger: Optional[int] = None,
     python_expires: Optional[bool] = None,
 ) -> dict:
@@ -453,11 +453,9 @@ def refresh(wrapped: Callable) -> Callable:
 
 
 class SerializerInterface(Protocol):
-    def dumps(self, s: str) -> bytes:
-        ...
+    def dumps(self, s: str) -> bytes: ...
 
-    def loads(self, s: bytes) -> str:
-        ...
+    def loads(self, s: bytes) -> str: ...
 
 
 class _NullSerializer(object):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # stdlib
 import pickle
+from typing import Any
+from typing import Dict
+from typing import Optional
 
 # pypi
 from redis.exceptions import WatchError
@@ -39,6 +42,10 @@ class DummySession(object):
 
 
 class DummyRedis(object):
+    url: Optional[str]
+    timeouts: Dict[str, int]
+    store: Dict[str, Any]
+
     def __init__(self, raise_watcherror=False, **kw):
         self.url = None
         self.timeouts = {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 # stdlib
+from typing import Dict
+from typing import Union
 import unittest
 
 # pypi
@@ -8,6 +10,7 @@ from pyramid import testing
 from pyramid.exceptions import ConfigurationError
 from pyramid.request import Request
 from pyramid.threadlocal import get_current_request
+from typing_extensions import Literal
 
 # local
 from pyramid_session_redis.exceptions import InvalidSession
@@ -25,7 +28,7 @@ _id_path = "tests.test_config.dummy_id_generator"
 _client_path = "tests.test_config.dummy_client_callable"
 _invalid_logger = "tests.test_config.dummy_invalid_logger"
 
-TEST_PSR_CONFIG = {
+TEST_PSR_CONFIG: Dict[str, Union[str, int]] = {
     "redis.sessions.secret": "supersecret",
     "redis.sessions.db": 9,
     "redis.sessions.serialize": "pickle.dumps",
@@ -48,11 +51,11 @@ def dummy_id_generator() -> str:
 
 
 # used to ensure includeme can resolve a dotted path to a redis client callable
-def dummy_client_callable(request: Request, **opts):
+def dummy_client_callable(request: Request, **opts) -> str:
     return "client"
 
 
-def dummy_invalid_logger(request: Request, raised: Exception):
+def dummy_invalid_logger(request: Request, raised: Exception) -> Literal[True]:
     assert isinstance(raised, InvalidSession)
     return True
 
@@ -97,7 +100,7 @@ class Test_includeme_simple(unittest.TestCase):
     def test_includeme_id_generator(self):
         request = get_current_request()  # noqa: F841
         generator = self.settings["redis.sessions.id_generator"]
-        self.assertEqual(generator(), 42)
+        self.assertEqual(generator(), "42")
 
     def test_includeme_client_callable(self):
         request = get_current_request()
@@ -109,7 +112,7 @@ class Test_includeme_simple(unittest.TestCase):
         logging_func = self.settings["redis.sessions.func_invalid_logger"]
         raised_error = InvalidSession_DeserializationError("foo")
         # check to ensure this is an InvalidSession instance
-        self.assertTrue(logging_func(raised_error))
+        self.assertTrue(logging_func(request, raised_error))
 
 
 class Test_includeme_advanced(unittest.TestCase):

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -7,6 +7,8 @@ import re
 from typing import Callable
 from typing import Dict
 from typing import Optional
+from typing import TYPE_CHECKING
+from typing import Union
 import unittest
 
 # pypi
@@ -38,6 +40,9 @@ from . import DummyRedis  # redis Client
 from .test_config import dummy_id_generator
 
 
+if TYPE_CHECKING:
+    from redis.client import Redis as RedisClient
+
 # ==============================================================================
 
 
@@ -60,7 +65,9 @@ class _TestRedisSessionFactoryCore(unittest.TestCase):
         session = RedisSessionFactory(secret, **kw)(request)
         return session
 
-    def _makeOneSession(self, redis: DummyRedis, session_id: str, **kw) -> RedisSession:
+    def _makeOneSession(
+        self, redis: Union[DummyRedis, "RedisClient"], session_id: str, **kw
+    ) -> RedisSession:
         _set_redis_ttl_onexit = False
         if (kw.get("timeout") and kw.get("set_redis_ttl")) and (
             not kw.get("timeout_trigger")

--- a/tests/test_pyramid.py
+++ b/tests/test_pyramid.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+
+# stdlib
+from typing import Dict
+from typing import Optional
+import unittest
+
+# pypi
+from pyramid import testing
+from pyramid.request import Request
+from pyramid.router import Router
+import pyramid.scripting
+from webtest import TestApp
+
+# from pyramid.paster import get_appsettings
+
+# local
+from .test_config import LIVE_PSR_CONFIG
+from .web_app import main
+from pyramid_session_redis.session import RedisSession
+
+# ==============================================================================
+
+
+class AppTest(unittest.TestCase):
+    _testapp: Optional[TestApp] = None
+    _pyramid_app: Router
+    _settings: Dict = LIVE_PSR_CONFIG
+
+    def setUp(self) -> None:
+        self._pyramid_app = app = main(None, **self._settings)
+        self._testapp = TestApp(app)
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def test_session_access__none(self):
+        request = Request.blank("/session_access__none")
+        with pyramid.scripting.prepare(
+            registry=self._pyramid_app.registry,
+            request=request,
+        ) as env:
+            assert request == env["request"]
+            assert isinstance(request.session, RedisSession)
+            assert not request.session.keys()  # request not invoked
+            res = self._testapp.app.invoke_request(request)
+            assert res.text == "<body><h1>session_access__none</h1></body>"
+            assert "Set-Cookie" not in res.headers
+            """
+            request.response
+            request.response.headers
+            request.response.text
+            """
+
+    def test_session_access__set_unset(self):
+        """
+        Edge A-
+            calling set and unset within a single request
+            SHOULD NOT persist the empty session
+        """
+        request = Request.blank("/session_access__set_unset")
+        with pyramid.scripting.prepare(
+            registry=self._pyramid_app.registry,
+            request=request,
+        ) as env:
+            assert request == env["request"]
+            assert isinstance(request.session, RedisSession)
+            assert not request.session.keys()  # request not invoked
+            res = self._testapp.app.invoke_request(request)
+            assert res.text == "<body><h1>session_access__set_unset</h1></body>"
+            assert "Set-Cookie" not in res.headers
+
+    def test_session_access__set(self):
+        """
+        Edge B
+            calling:
+            * set on request 1;
+            * unset on request 2
+            SHOULD persist the empty session
+        """
+        session_id: str
+        session_cookie: str
+        request = Request.blank("/session_access__set")
+        with pyramid.scripting.prepare(
+            registry=self._pyramid_app.registry,
+            request=request,
+        ) as env:
+            assert request == env["request"]
+            assert isinstance(request.session, RedisSession)
+            assert not request.session.keys()  # request not invoked
+            res = self._testapp.app.invoke_request(request)
+            assert res.text == "<body><h1>session_access__set</h1></body>"
+            assert "Set-Cookie" in res.headers
+            session_id = request.session.session_id  # noqa: F841
+            session_cookie = res.headers["Set-Cookie"]
+            # this will look like `session=X'; Path=/; HttpOnly"
+            session_cookie = (session_cookie.split(";")[0]).strip()
+        headers_in = {"Cookie": session_cookie}
+        request2 = Request.blank("/session_access__unset", headers=headers_in)
+        with pyramid.scripting.prepare(
+            registry=self._pyramid_app.registry,
+            request=request2,
+        ) as env:
+            assert request2 == env["request"]
+            assert isinstance(request2.session, RedisSession)
+            assert (
+                "a" in request2.session.keys()
+            )  # request not invoked, but we can load it
+            res2 = self._testapp.app.invoke_request(request2)
+            assert (
+                "a" not in request2.session.keys()
+            )  # request invoked, session cleared
+            assert not request2.session.keys()  # request invoked, cleared in view
+            assert res2.text == "<body><h1>session_access__unset</h1></body>"
+            assert "Set-Cookie" in res.headers

--- a/tests/test_pyramid.py
+++ b/tests/test_pyramid.py
@@ -3,6 +3,7 @@
 # stdlib
 from typing import Dict
 from typing import Optional
+from typing import TYPE_CHECKING
 import unittest
 
 # pypi
@@ -15,9 +16,9 @@ from webtest import TestApp
 # from pyramid.paster import get_appsettings
 
 # local
+from pyramid_session_redis.session import RedisSession
 from .test_config import LIVE_PSR_CONFIG
 from .web_app import main
-from pyramid_session_redis.session import RedisSession
 
 # ==============================================================================
 
@@ -70,7 +71,7 @@ class AppTest(unittest.TestCase):
             assert res.text == "<body><h1>session_access__set_unset</h1></body>"
             assert "Set-Cookie" not in res.headers
 
-    def test_session_access__set(self):
+    def test_session_access__set(self) -> None:
         """
         Edge B
             calling:
@@ -78,6 +79,8 @@ class AppTest(unittest.TestCase):
             * unset on request 2
             SHOULD persist the empty session
         """
+        if TYPE_CHECKING:
+            assert self._testapp is not None
         session_id: str
         session_cookie: str
         request = Request.blank("/session_access__set")

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 
 # stdlib
 import unittest

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # stdlib
+from typing import Optional
 import unittest
 
 # pypi
@@ -10,6 +11,7 @@ from webob.cookies import SignedSerializer
 from pyramid_session_redis.exceptions import InvalidSessionId_Serialization
 from pyramid_session_redis.legacy import GracefulCookieSerializer
 from pyramid_session_redis.legacy import LegacyCookieSerializer
+from pyramid_session_redis.legacy import LoggingHookInterface
 from pyramid_session_redis.util import _NullSerializer
 
 
@@ -39,7 +41,7 @@ class TestNullSerializer(unittest.TestCase):
 
 
 class TestCookieSerialization(unittest.TestCase):
-    def _makeOne_default(self, secret):
+    def _makeOne_default(self, secret: str) -> SignedSerializer:
         cookie_signer = SignedSerializer(
             secret,
             "pyramid_session_redis.",
@@ -48,11 +50,15 @@ class TestCookieSerialization(unittest.TestCase):
         )
         return cookie_signer
 
-    def _makeOne_legacy(self, secret):
+    def _makeOne_legacy(self, secret: str) -> LegacyCookieSerializer:
         cookie_signer = LegacyCookieSerializer(secret)
         return cookie_signer
 
-    def _makeOne_graceful(self, secret, logging_hook=None):
+    def _makeOne_graceful(
+        self,
+        secret: str,
+        logging_hook: Optional[LoggingHookInterface] = None,
+    ) -> GracefulCookieSerializer:
         cookie_signer = GracefulCookieSerializer(
             secret,
             logging_hook=logging_hook,
@@ -116,19 +122,19 @@ class TestCookieSerialization(unittest.TestCase):
         secret = "foo"
         session_id = "session_id:123"
 
-        class LoggingHook(object):
+        class LoggingHook(LoggingHookInterface):
             def __init__(self):
                 self._attempts_global = []
                 self._attempts = []
                 self._successes = []
 
-            def attempt(self, serializer):
+            def attempt(self, serializer: str) -> None:
                 if serializer == "global":
                     self._attempts_global.append(serializer)
                 else:
                     self._attempts.append(serializer)
 
-            def success(self, serializer):
+            def success(self, serializer: str) -> None:
                 self._successes.append(serializer)
 
         logging_hook = LoggingHook()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 
 # stdlib
 import itertools

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 class TestRedisSession(unittest.TestCase):
     def _makeOne(
         self,
-        redis: DummyRedis,
+        redis: Union[DummyRedis, "RedisClient"],
         session_id: str,
         new: bool,
         func_new_session: Callable,
@@ -67,7 +67,7 @@ class TestRedisSession(unittest.TestCase):
 
     def _set_up_session_in_redis(
         self,
-        redis: "DummyRedis",
+        redis: Union[DummyRedis, "RedisClient"],
         session_id: str,
         timeout: int = 0,
         session_dict: Optional[dict] = None,
@@ -669,7 +669,7 @@ class _TestRedisSessionNew_CORE(object):
 
     def _set_up_session_in_redis(
         self,
-        redis: DummyRedis,
+        redis: Union[DummyRedis, "RedisClient"],
         session_id: str,
         timeout: int = 0,
         session_dict: Optional[dict] = None,
@@ -759,7 +759,9 @@ class _TestRedisSessionNew_CORE(object):
         )
 
     def _deserialize_session(
-        self, session: RedisSession, deserialize=pickle.loads
+        self,
+        session: RedisSession,
+        deserialize=pickle.loads,
     ) -> dict:
         _session_id = session.session_id
         _session_data = session.redis._store[_session_id]

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -2,8 +2,12 @@
 
 # stdlib
 import os
+from typing import Any
 from typing import Dict
 from typing import Optional
+from typing import Tuple
+from typing import TYPE_CHECKING
+from typing import Union
 import unittest
 
 # pypi
@@ -41,13 +45,13 @@ class _FakeResponse(object):
     req: Optional[_FakeRequest] = None
     cookies: Optional[Dict[str, bytes]] = None
 
-    def __init__(self, req: Optional[_FakeRequest] = None):
+    def __init__(self, req: Optional[_FakeRequest] = None) -> None:
         self.cookies = {}
         self.req = req
         if self.req:
             self.req.response = self
 
-    def set_cookie(self, name: str, value: str):
+    def set_cookie(self, name: str, value: Union[str, bytes]) -> None:
         _value: bytes
         if isinstance(value, str):
             _value = value.encode()
@@ -66,7 +70,9 @@ class Test_GetSessionIdFromCookie(unittest.TestCase):
     `_get_session_id_from_cookie`
     """
 
-    def _makeOne(self, cookie_name, cookie_value):
+    def _makeOne(
+        self, cookie_name: str, cookie_value: str
+    ) -> Tuple[_FakeResponse, _NullSerializer]:
         serializer = _NullSerializer()
         if isinstance(cookie_value, str):
             _cookie_value = serializer.dumps(cookie_value)
@@ -79,6 +85,8 @@ class Test_GetSessionIdFromCookie(unittest.TestCase):
         req = _FakeRequest()
         res = _FakeResponse(req)
         res.set_cookie(cookie_name, _cookie_value)
+        if TYPE_CHECKING:
+            assert res.cookies is not None
         self.assertIn(cookie_name, res.cookies)
         _value_encoded = res.cookies[cookie_name]
         self.assertEqual(type(_value_encoded), bytes)
@@ -90,8 +98,10 @@ class Test_GetSessionIdFromCookie(unittest.TestCase):
         value_in,  # raw value in
         value_encoded,  # encoded into Response; must be bytes
         value_decoded,  # decoded from request
-    ):
+    ) -> None:
         res, serializer = self._makeOne(cookie_name, value_in)
+        if TYPE_CHECKING:
+            assert res.cookies is not None
         _decoded = _get_session_id_from_cookie(res, cookie_name, serializer)
         self.assertIn(cookie_name, res.cookies)
         self.assertEqual(res.cookies[cookie_name], value_encoded)
@@ -143,7 +153,9 @@ class Test_CookieSigner_NullSerializer(unittest.TestCase):
        export GENERATE_COOKIE_DATA=1
     """
 
-    def _makeOne(self, cookie_name, cookie_value):
+    def _makeOne(
+        self, cookie_name: str, cookie_value: str
+    ) -> Tuple[_FakeResponse, SignedSerializer]:
         cookie_signer = SignedSerializer(
             "secret",
             "pyramid_session_redis.",
@@ -168,8 +180,12 @@ class Test_CookieSigner_NullSerializer(unittest.TestCase):
             print("  signed:", _cookie_value)
         return res, cookie_signer
 
-    def _test_setup(self, cookie_name, value_in, value_expected, value_signed):
+    def _test_setup(
+        self, cookie_name: str, value_in: Any, value_expected: Any, value_signed: str
+    ) -> None:
         res, cookie_signer = self._makeOne(cookie_name, value_in)
+        if TYPE_CHECKING:
+            assert res.cookies is not None
         self.assertIn(cookie_name, res.cookies)
         self.assertEqual(res.cookies[cookie_name], value_signed)
         value_out = _get_session_id_from_cookie(res, cookie_name, cookie_signer)
@@ -218,7 +234,9 @@ class Test_CookieSigner_DefaultSerializer(unittest.TestCase):
        export GENERATE_COOKIE_DATA=1
     """
 
-    def _makeOne(self, cookie_name, cookie_value):
+    def _makeOne(
+        self, cookie_name: str, cookie_value: str
+    ) -> Tuple[_FakeResponse, SignedSerializer]:
         cookie_signer = SignedSerializer(
             "secret",
             "pyramid_session_redis.",
@@ -239,8 +257,12 @@ class Test_CookieSigner_DefaultSerializer(unittest.TestCase):
             print("  signed:", _cookie_value)
         return res, cookie_signer
 
-    def _test_setup(self, cookie_name, value_in, value_expected, value_signed):
+    def _test_setup(
+        self, cookie_name: str, value_in: Any, value_expected: Any, value_signed: str
+    ) -> None:
         res, cookie_signer = self._makeOne(cookie_name, value_in)
+        if TYPE_CHECKING:
+            assert res.cookies is not None
         self.assertIn(cookie_name, res.cookies)
         self.assertEqual(res.cookies[cookie_name], value_signed)
         value_out = _get_session_id_from_cookie(res, cookie_name, cookie_signer)
@@ -284,7 +306,7 @@ class Test_CookieSigner_Invalids(unittest.TestCase):
     """
 
     def test_webob_default(self):
-        cookie_name = "test_string"
+        # cookie_name = "test_string"
         # mess up a value from something else
         value_signed = b"r3pVu9XGVFfz1MZQYdVT9kWVrb94mZT1TdL8HNYnFVf5cDcXPaL4ULuQ_GZ7hNAZNQCwfSRSGuffr6eQTgoHBSJzdHJpbmcJ"
 
@@ -295,11 +317,11 @@ class Test_CookieSigner_Invalids(unittest.TestCase):
             "sha512",
         )
         with self.assertRaises(ValueError) as ctx:
-            _cookie_value = cookie_signer.loads(value_signed)
+            _cookie_value = cookie_signer.loads(value_signed)  # noqa: F841
         self.assertEqual(ctx.exception.args[0], "Invalid signature")
 
     def test_our_default(self):
-        cookie_name = "test_string"
+        # cookie_name = "test_string"
         # mess up a value from something else
         value_signed = b"r3pVu9XGVFfz1MZQYdVT9kWVrb94mZT1TdL8HNYnFVf5cDcXPaL4ULuQ_GZ7hNAZNQCwfSRSGuffr6eQTgoHBSJzdHJpbmcJ"
 
@@ -311,7 +333,7 @@ class Test_CookieSigner_Invalids(unittest.TestCase):
             serializer=_NullSerializer(),
         )
         with self.assertRaises(ValueError) as ctx:
-            _cookie_value = cookie_signer.loads(value_signed)
+            _cookie_value = cookie_signer.loads(value_signed)  # noqa: F841
         self.assertEqual(ctx.exception.args[0], "Invalid signature")
 
     def test_crafted_malicious_1(self):
@@ -319,7 +341,7 @@ class Test_CookieSigner_Invalids(unittest.TestCase):
         WRITE w/json;
         READ w/str
         """
-        cookie_name = "test_int"
+        # cookie_name = "test_int"
         cookie_value = {"a": False, "b": {"c": 1, "d": "e"}}
 
         # by default this will use a JSON serialization

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -23,6 +23,8 @@ from pyramid_session_redis.util import _NullSerializer
 # export GENERATE_COOKIE_DATA=1
 GENERATE_COOKIE_DATA = bool(int(os.getenv("GENERATE_COOKIE_DATA", "0")))
 
+TYPE_COOKIES = Optional[Dict[str, bytes]]
+
 # ----
 
 
@@ -34,7 +36,7 @@ class _FakeRequest(object):
     response: Optional["_FakeResponse"] = None
 
     @property
-    def cookies(self):
+    def cookies(self) -> TYPE_COOKIES:
         """proxy against response.set_cookie to loosely mimic interace"""
         if self.response:
             return self.response.cookies
@@ -43,10 +45,10 @@ class _FakeRequest(object):
 
 class _FakeResponse(object):
     req: Optional[_FakeRequest] = None
-    cookies: Optional[Dict[str, bytes]] = None
+    cookies: TYPE_COOKIES = None
 
     def __init__(self, req: Optional[_FakeRequest] = None) -> None:
-        self.cookies = {}
+        self.cookies: TYPE_COOKIES = {}
         self.req = req
         if self.req:
             self.req.response = self
@@ -71,7 +73,9 @@ class Test_GetSessionIdFromCookie(unittest.TestCase):
     """
 
     def _makeOne(
-        self, cookie_name: str, cookie_value: str
+        self,
+        cookie_name: str,
+        cookie_value: str,
     ) -> Tuple[_FakeResponse, _NullSerializer]:
         serializer = _NullSerializer()
         if isinstance(cookie_value, str):
@@ -94,10 +98,10 @@ class Test_GetSessionIdFromCookie(unittest.TestCase):
 
     def _test_setup(
         self,
-        cookie_name,
+        cookie_name: str,
         value_in,  # raw value in
-        value_encoded,  # encoded into Response; must be bytes
-        value_decoded,  # decoded from request
+        value_encoded: bytes,  # encoded into Response; must be bytes
+        value_decoded: str,  # decoded from request
     ) -> None:
         res, serializer = self._makeOne(cookie_name, value_in)
         if TYPE_CHECKING:
@@ -154,7 +158,9 @@ class Test_CookieSigner_NullSerializer(unittest.TestCase):
     """
 
     def _makeOne(
-        self, cookie_name: str, cookie_value: str
+        self,
+        cookie_name: str,
+        cookie_value: str,
     ) -> Tuple[_FakeResponse, SignedSerializer]:
         cookie_signer = SignedSerializer(
             "secret",
@@ -181,7 +187,11 @@ class Test_CookieSigner_NullSerializer(unittest.TestCase):
         return res, cookie_signer
 
     def _test_setup(
-        self, cookie_name: str, value_in: Any, value_expected: Any, value_signed: str
+        self,
+        cookie_name: str,
+        value_in: Any,
+        value_expected: Any,
+        value_signed: str,
     ) -> None:
         res, cookie_signer = self._makeOne(cookie_name, value_in)
         if TYPE_CHECKING:
@@ -235,7 +245,9 @@ class Test_CookieSigner_DefaultSerializer(unittest.TestCase):
     """
 
     def _makeOne(
-        self, cookie_name: str, cookie_value: str
+        self,
+        cookie_name: str,
+        cookie_value: str,
     ) -> Tuple[_FakeResponse, SignedSerializer]:
         cookie_signer = SignedSerializer(
             "secret",
@@ -258,7 +270,11 @@ class Test_CookieSigner_DefaultSerializer(unittest.TestCase):
         return res, cookie_signer
 
     def _test_setup(
-        self, cookie_name: str, value_in: Any, value_expected: Any, value_signed: str
+        self,
+        cookie_name: str,
+        value_in: Any,
+        value_expected: Any,
+        value_signed: str,
     ) -> None:
         res, cookie_signer = self._makeOne(cookie_name, value_in)
         if TYPE_CHECKING:

--- a/tests/web_app.py
+++ b/tests/web_app.py
@@ -1,4 +1,5 @@
 # stdlib
+from typing import Optional
 
 # pypi
 from pyramid.config import Configurator
@@ -12,22 +13,22 @@ from .test_config import LIVE_PSR_CONFIG
 # ==============================================================================
 
 
-def session_access__none(request: Request):
+def session_access__none(request: Request) -> Response:
     return Response("<body><h1>session_access__none</h1></body>")
 
 
-def session_access__set(request: Request):
+def session_access__set(request: Request) -> Response:
     request.session["a"] = 1
     return Response("<body><h1>session_access__set</h1></body>")
 
 
-def session_access__set_unset(request: Request):
+def session_access__set_unset(request: Request) -> Response:
     request.session["a"] = 1
     del request.session["a"]
     return Response("<body><h1>session_access__set_unset</h1></body>")
 
 
-def session_access__unset(request: Request):
+def session_access__unset(request: Request) -> Response:
     try:
         del request.session["a"]
     except Exception:
@@ -35,7 +36,7 @@ def session_access__unset(request: Request):
     return Response("<body><h1>session_access__unset</h1></body>")
 
 
-def main(global_config, **settings):
+def main(global_config: Optional[str], **settings):
     """This function returns a Pyramid WSGI application."""
     config = Configurator(settings=settings)
     config.include("pyramid_session_redis")

--- a/tests/web_app.py
+++ b/tests/web_app.py
@@ -1,0 +1,69 @@
+# stdlib
+
+# pypi
+from pyramid.config import Configurator
+from pyramid.request import Request
+from pyramid.response import Response
+from waitress import serve
+
+# local
+from .test_config import LIVE_PSR_CONFIG
+
+# ==============================================================================
+
+
+def session_access__none(request: Request):
+    return Response("<body><h1>session_access__none</h1></body>")
+
+
+def session_access__set(request: Request):
+    request.session["a"] = 1
+    return Response("<body><h1>session_access__set</h1></body>")
+
+
+def session_access__set_unset(request: Request):
+    request.session["a"] = 1
+    del request.session["a"]
+    return Response("<body><h1>session_access__set_unset</h1></body>")
+
+
+def session_access__unset(request: Request):
+    try:
+        del request.session["a"]
+    except Exception:
+        pass
+    return Response("<body><h1>session_access__unset</h1></body>")
+
+
+def main(global_config, **settings):
+    """This function returns a Pyramid WSGI application."""
+    config = Configurator(settings=settings)
+    config.include("pyramid_session_redis")
+
+    # --------------------------------------------------------------------------
+
+    # session_access__none
+    config.add_route("session_access__none", "/session_access__none")
+    config.add_view(session_access__none, route_name="session_access__none")
+
+    # session_access__set
+    config.add_route("session_access__set", "/session_access__set")
+    config.add_view(session_access__set, route_name="session_access__set")
+
+    # session_access__set_unset
+    config.add_route("session_access__set_unset", "/session_access__set_unset")
+    config.add_view(session_access__set_unset, route_name="session_access__set_unset")
+
+    # session_access__unset
+    config.add_route("session_access__unset", "/session_access__unset")
+    config.add_view(session_access__unset, route_name="session_access__unset")
+
+    # --------------------------------------------------------------------------
+
+    app = config.make_wsgi_app()
+    return app
+
+
+if __name__ == "__main__":
+    app = main(None, **LIVE_PSR_CONFIG)
+    serve(app, host="0.0.0.0", port=6543)


### PR DESCRIPTION
While reviewing code to see if #67 could be handled through a private API, I noticed these lines:

https://github.com/jvanasco/pyramid_session_redis/blob/v1.7.0rc1/src/pyramid_session_redis/session.py#L499-L504

https://github.com/jvanasco/pyramid_session_redis/blob/v1.7.0rc1/src/pyramid_session_redis/__init__.py#L793-L807

This made me wonder the following, which required tests 

* If a NEW session is created, but then empty on the same request, is it created?
* If an existing session is emptied, is the session destroyed?

Answers:

* In the first situation, no session is persisted.
* In the second situation, we persist an empty session

The code should be changed to destroy an empty session on the browser and in Redis.  



