### PR TITLE
Use a `redis_` prefix to replace redis kwargs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Changelog
 	* drop testing/support for python3.6 due to github removing ubuntu20.04
 	* update pre-commit to use flake8 and a CI version of black
 	* minimum redis Python API is now 4.0.0 (November 15 2021)
-    * removed deprecated redis commands:
+    * removed deprecated redis kwargs:
         ``socket_timeout``
             replaced by  ``redis_socket_timeout``.
         ``connection_pool``
@@ -20,13 +20,21 @@ Changelog
         ``unix_socket_path``
             replaced by ``redis_unix_socket_path``.
     * util.SerializerInterface is deprecated and replaced with util.SignedSerializerInterface
-       - this will be removed in the next minor release
+       - this will be removed in the next minor release (1.8)
     * the entire `pyramid_session_redis.legacy` namespace has been deprecated.
       this namespace existed to migrate off the `pyramid_redis_session` package
       that package has not been updated in 9 years, and last supported python 3.4
-       - this will be removed in the next minor release
+       - this will be removed in the next minor release (1.8)
     * _NullSerializer has been deprecated and renamed to _StringSerializer
     * introduce `invalidate_empty_session` to automatically clear sessions
+    * deprecate additional redis kwargs, in favor of variants with a `redis_` prefix:
+        url -> redis_url
+        host -> redis_host
+        port -> redis_port
+        db -> redis_db
+        password -> redis_password
+        client_callable -> redis_client_callable
+       - this will be removed in the next minor release (1.8)
 
 * 2023.06.13
     * version 1.7.0rc1

--- a/TODO.md
+++ b/TODO.md
@@ -12,3 +12,14 @@ The existing tests on this concept are largely from pyramid_redis_session and ma
 
 * Creating a new session still takes 2 SET/SETEX calls -- one for a placeholder, the next to update.  This should be consolidated into one. (was this done already?)
 
+# Tests should use mocks or protocols
+
+There are some issues with typing, because tests use DummyRedis not Redis, etc.
+
+* DummyClass args are invalid
+* RealClasses don't have certain attributes
+
+Examples::
+
+*  tests/test_connection.py:36: error: Argument "client_class" to "get_default_connection" has incompatible type "type[DummyRedis]"; expected "type[Redis]"  [arg-type]
+* tests/test_connection.py:38: error: "Redis" has no attribute "url"  [attr-defined]

--- a/src/pyramid_session_redis/__init__.py
+++ b/src/pyramid_session_redis/__init__.py
@@ -127,11 +127,11 @@ def RedisSessionFactory(
     cookie_on_exception: bool = True,
     url: Optional[str] = None,  # DEPRECATED in 1.7; REMOVING in 1.8
     redis_url: Optional[str] = None,
-    host: str = "localhost",
+    host: Optional[str] = None,
     redis_host: str = "localhost",  # DEPRECATED in 1.7; REMOVING in 1.8
-    port: int = 6379,  # DEPRECATED in 1.7; REMOVING in 1.8
+    port: Optional[int] = None,  # DEPRECATED in 1.7; REMOVING in 1.8
     redis_port: int = 6379,
-    db: int = 0,  # DEPRECATED in 1.7; REMOVING in 1.8
+    db: Optional[int] = None,  # DEPRECATED in 1.7; REMOVING in 1.8
     redis_db: int = 0,
     password: Optional[str] = None,  # DEPRECATED in 1.7; REMOVING in 1.8
     redis_password: Optional[str] = None,

--- a/src/pyramid_session_redis/__init__.py
+++ b/src/pyramid_session_redis/__init__.py
@@ -125,17 +125,19 @@ def RedisSessionFactory(
     cookie_comment: Optional[str] = None,
     cookie_samesite: Optional[str] = None,
     cookie_on_exception: bool = True,
-    url: Optional[str] = None,  # DEPRECATED
+    url: Optional[str] = None,  # DEPRECATED in 1.7; REMOVING in 1.8
     redis_url: Optional[str] = None,
     host: str = "localhost",
-    redis_host: str = "localhost",  # DEPRECATED
-    port: int = 6379,  # DEPRECATED
+    redis_host: str = "localhost",  # DEPRECATED in 1.7; REMOVING in 1.8
+    port: int = 6379,  # DEPRECATED in 1.7; REMOVING in 1.8
     redis_port: int = 6379,
-    db: int = 0,  # DEPRECATED
+    db: int = 0,  # DEPRECATED in 1.7; REMOVING in 1.8
     redis_db: int = 0,
-    password: Optional[str] = None,  # DEPRECATED
+    password: Optional[str] = None,  # DEPRECATED in 1.7; REMOVING in 1.8
     redis_password: Optional[str] = None,
-    client_callable: Optional[Callable[..., "RedisClient"]] = None,  # DEPRECATED
+    client_callable: Optional[
+        Callable[..., "RedisClient"]
+    ] = None,  # DEPRECATED in 1.7; REMOVING in 1.8
     redis_client_callable: Optional[Callable[..., "RedisClient"]] = None,
     serialize: Callable[[Dict], bytes] = pickle.dumps,  # dict->bytes
     deserialize: Callable[[bytes], Dict] = pickle.loads,  # bytes->dict
@@ -236,34 +238,34 @@ def RedisSessionFactory(
     If ``True``, set a session cookie even if an exception occurs
     while rendering a view.
 
-    ``url`` DEPRECATED
+    ``url`` DEPRECATED in 1.7; REMOVING in 1.8
     ``redis_url`` replacement
     Default: ``None``.
     A connection string for a Redis server, in the format:
     redis://username:password@localhost:6379/0
 
-    ``host`` DEPRECATED
+    ``host`` DEPRECATED in 1.7; REMOVING in 1.8
     ``redis_host`` replacement
     Default: ``localhost``.
     A string representing the IP of your Redis server.
 
-    ``port`` DEPRECATED
+    ``port`` DEPRECATED in 1.7; REMOVING in 1.8
     ``redis_port`` replacement
     Default: ``6379``.
     An integer representing the port of your Redis server.
 
-    ``db`` DEPRECATED
+    ``db`` DEPRECATED in 1.7; REMOVING in 1.8
     ``redis_db`` replacement
     Integer value; Default: ``0``
     An integer to select a specific database on your Redis server.
 
-    ``password`` DEPRECATED
+    ``password`` DEPRECATED in 1.7; REMOVING in 1.8
     ``redis_password`` replacement
     Default: ``None``.
     A string password to connect to your Redis server/database if
     required.
 
-    ``client_callable`` DEPRECATED
+    ``client_callable`` DEPRECATED in 1.7; REMOVING in 1.8
     ``redis_client_callable`` replacement
     Default: ``None``.
     A python callable that accepts a Pyramid `request` and Redis config options

--- a/src/pyramid_session_redis/util.py
+++ b/src/pyramid_session_redis/util.py
@@ -124,19 +124,26 @@ configs_str = (
     "cookie_domain",
     "cookie_comment",
     "cookie_samesite",
+    "host",  # DEPRECATED
+    "password",  # DEPRECATED
+    "redis_host",
+    "redis_password",
     "redis_unix_socket_path",
     "redis_encoding_errors",
     "redis_encoding",
+    "redis_url",
+    "url",  # DEPRECATED
 )
 
 # treat as strings here
 configs_dotable = (
-    "client_callable",
+    "client_callable",  # DEPRECATED
     "cookie_signer",
     "deserialize",
     "func_check_response_allow_cookies",
     "func_invalid_logger",
     "id_generator",
+    "redis_client_callable",
     "serialize",
 )
 
@@ -153,8 +160,10 @@ configs_bool = (
 )
 
 configs_int = (
-    "db",
-    "port",
+    "db",  # DEPRECATED
+    "port",  # DEPRECATED
+    "redis_db",
+    "redis_port",
 )
 
 configs_int_none = (

--- a/src/pyramid_session_redis/util.py
+++ b/src/pyramid_session_redis/util.py
@@ -124,20 +124,20 @@ configs_str = (
     "cookie_domain",
     "cookie_comment",
     "cookie_samesite",
-    "host",  # DEPRECATED
-    "password",  # DEPRECATED
+    "host",  # DEPRECATED in 1.7; REMOVING in 1.8
+    "password",  # DEPRECATED in 1.7; REMOVING in 1.8
     "redis_host",
     "redis_password",
     "redis_unix_socket_path",
     "redis_encoding_errors",
     "redis_encoding",
     "redis_url",
-    "url",  # DEPRECATED
+    "url",  # DEPRECATED in 1.7; REMOVING in 1.8
 )
 
 # treat as strings here
 configs_dotable = (
-    "client_callable",  # DEPRECATED
+    "client_callable",  # DEPRECATED in 1.7; REMOVING in 1.8
     "cookie_signer",
     "deserialize",
     "func_check_response_allow_cookies",
@@ -160,8 +160,8 @@ configs_bool = (
 )
 
 configs_int = (
-    "db",  # DEPRECATED
-    "port",  # DEPRECATED
+    "db",  # DEPRECATED in 1.7; REMOVING in 1.8
+    "port",  # DEPRECATED in 1.7; REMOVING in 1.8
     "redis_db",
     "redis_port",
 )
@@ -510,7 +510,7 @@ class SignedSerializerInterface(Protocol):
     def loads(self, s: bytes) -> str: ...
 
 
-# `SerializerInterface` is Deprecated in 1.7.x
+# `SerializerInterface` ; DEPRECATED in 1.7; REMOVING in 1.8
 SerializerInterface = SignedSerializerInterface
 
 
@@ -553,5 +553,5 @@ class _StringSerializer(SignedSerializerInterface):
             raise InvalidSessionId_Deserialization(exc)
 
 
-# `_NullSerializer` is Deprecated in 1.7.x
+# `_NullSerializer` DEPRECATED in 1.7; REMOVING in 1.8
 _NullSerializer = _StringSerializer


### PR DESCRIPTION
see #74 